### PR TITLE
Run MirrorIT on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
 
   sonarcloud:
     name: Run SonarCloud Analysis
-    needs: [linux-amd64, mac]
+    needs: [linux-amd64, mac, win-amd64]
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
@@ -97,6 +97,10 @@ jobs:
         with:
           name: coverage-mac
           path: coverage/mac
+      - uses: actions/download-artifact@v2
+        with:
+          name: coverage-win-amd64
+          path: coverage/win-amd64
       - name: Analyze
         run: >
           mvn -B compile -DskipTests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,27 @@ jobs:
           path: jfuse-tests/target/site/jacoco-aggregate/jacoco.xml
           retention-days: 3
 
+  win-amd64:
+    name: Test jfuse-win-amd64
+    runs-on: windows-latest
+    if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          java-version: 18-ea
+          distribution: 'zulu'
+          cache: 'maven'
+      - name: Setup fuse
+        run: choco install winfsp --version 1.10.22006 -y
+      - name: Maven build
+        run: mvn -B verify -Pwin-amd64
+      - uses: actions/upload-artifact@v2
+        with:
+          name: coverage-win-amd64
+          path: jfuse-tests/target/site/jacoco-aggregate/jacoco.xml
+          retention-days: 3
+
   sonarcloud:
     name: Run SonarCloud Analysis
     needs: [linux-amd64, mac]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,6 @@ jobs:
     name: Run SonarCloud Analysis
     needs: [linux-amd64, mac, win-amd64]
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - uses: actions/checkout@v2
         with:

--- a/jfuse-examples/src/main/java/org/cryptomator/jfuse/examples/PosixMirrorFileSystem.java
+++ b/jfuse-examples/src/main/java/org/cryptomator/jfuse/examples/PosixMirrorFileSystem.java
@@ -38,6 +38,8 @@ public final class PosixMirrorFileSystem extends AbstractMirrorFileSystem {
 			} else {
 				LOG.error("Failed to mount to {}. Exit code: {}", mountPoint, result);
 			}
+			System.out.println("Enter a anything to unmount...");
+			System.in.read();
 		} catch (TimeoutException | CompletionException e) {
 			LOG.error("Un/Mounting failed. ", e);
 			System.exit(1);

--- a/jfuse-examples/src/main/java/org/cryptomator/jfuse/examples/PosixMirrorFileSystem.java
+++ b/jfuse-examples/src/main/java/org/cryptomator/jfuse/examples/PosixMirrorFileSystem.java
@@ -38,7 +38,7 @@ public final class PosixMirrorFileSystem extends AbstractMirrorFileSystem {
 			} else {
 				LOG.error("Failed to mount to {}. Exit code: {}", mountPoint, result);
 			}
-			System.out.println("Enter a anything to unmount...");
+			LOG.info("Enter a anything to unmount...");
 			System.in.read();
 		} catch (TimeoutException | CompletionException e) {
 			LOG.error("Un/Mounting failed. ", e);

--- a/jfuse-examples/src/main/java/org/cryptomator/jfuse/examples/WindowsMirrorFileSystem.java
+++ b/jfuse-examples/src/main/java/org/cryptomator/jfuse/examples/WindowsMirrorFileSystem.java
@@ -37,7 +37,7 @@ public final class WindowsMirrorFileSystem extends AbstractMirrorFileSystem {
 			} else {
 				LOG.error("Failed to mount to {}. Exit code: {}", mountPoint, result);
 			}
-			System.out.println("Enter a anything to unmount...");
+			LOG.info("Enter a anything to unmount...");
 			System.in.read();
 		} catch (TimeoutException | CompletionException e) {
 			LOG.error("Un/Mounting failed. ", e);

--- a/jfuse-examples/src/main/java/org/cryptomator/jfuse/examples/WindowsMirrorFileSystem.java
+++ b/jfuse-examples/src/main/java/org/cryptomator/jfuse/examples/WindowsMirrorFileSystem.java
@@ -37,6 +37,8 @@ public final class WindowsMirrorFileSystem extends AbstractMirrorFileSystem {
 			} else {
 				LOG.error("Failed to mount to {}. Exit code: {}", mountPoint, result);
 			}
+			System.out.println("Enter a anything to unmount...");
+			System.in.read();
 		} catch (TimeoutException | CompletionException e) {
 			LOG.error("Un/Mounting failed. ", e);
 			System.exit(1);

--- a/jfuse-tests/src/test/java/org/cryptomator/jfuse/tests/MirrorIT.java
+++ b/jfuse-tests/src/test/java/org/cryptomator/jfuse/tests/MirrorIT.java
@@ -48,20 +48,12 @@ public class MirrorIT {
 		AbstractMirrorFileSystem fs;
 		List<String> flags = new ArrayList<>();
 		flags.add("-s");
+		mirror = tmpDir.resolve("mirror");
 		if (OS.WINDOWS.isCurrentOs()) {
-			//Idea: read from system property! in build script we can set it via "-DmyProp=.."
-			var ciMountPath = System.getProperty(WIN_MOUNT_DIR_PROP);
-			if( ciMountPath != null) {
-				mirror = Path.of(ciMountPath).resolve("mnt");
-			} else {
-				mirror = Path.of("M:\\");
-			}
-			Assumptions.assumeTrue(Files.notExists(mirror), "M: drive occupied");
-			fs = new WindowsMirrorFileSystem(orig, builder.errno());
 			flags.add("-ouid=-1");
 			flags.add("-ogid=-1");
+			fs = new WindowsMirrorFileSystem(orig, builder.errno());
 		} else {
-			mirror = tmpDir.resolve("mirror");
 			Files.createDirectories(mirror);
 			fs = new PosixMirrorFileSystem(orig, builder.errno());
 		}

--- a/jfuse-tests/src/test/java/org/cryptomator/jfuse/tests/MirrorIT.java
+++ b/jfuse-tests/src/test/java/org/cryptomator/jfuse/tests/MirrorIT.java
@@ -69,7 +69,7 @@ public class MirrorIT {
 			Process p = command.start();
 			p.waitFor(10, TimeUnit.SECONDS);
 		}
-		// TODO add win-specific unmount code
+		// for Windows we call internally fuse_exit
 		if (fuse != null) {
 			Assertions.assertTimeoutPreemptively(Duration.ofSeconds(10), fuse::close, "file system still active");
 		}

--- a/jfuse-tests/src/test/java/org/cryptomator/jfuse/tests/MirrorIT.java
+++ b/jfuse-tests/src/test/java/org/cryptomator/jfuse/tests/MirrorIT.java
@@ -34,6 +34,8 @@ import java.util.concurrent.TimeoutException;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class MirrorIT {
 
+	private static final String WIN_MOUNT_DIR_PROP = "jfuse.win.integrationMountDir";
+
 	private Path orig;
 	private Path mirror;
 	private Fuse fuse;
@@ -47,7 +49,13 @@ public class MirrorIT {
 		List<String> flags = new ArrayList<>();
 		flags.add("-s");
 		if (OS.WINDOWS.isCurrentOs()) {
-			mirror = Path.of("M:\\");
+			//Idea: read from system property! in build script we can set it via "-DmyProp=.."
+			var ciMountPath = System.getProperty(WIN_MOUNT_DIR_PROP);
+			if( ciMountPath != null) {
+				mirror = Path.of(ciMountPath).resolve("mnt");
+			} else {
+				mirror = Path.of("M:\\");
+			}
 			Assumptions.assumeTrue(Files.notExists(mirror), "M: drive occupied");
 			fs = new WindowsMirrorFileSystem(orig, builder.errno());
 			flags.add("-ouid=-1");

--- a/jfuse-tests/src/test/java/org/cryptomator/jfuse/tests/MirrorIT.java
+++ b/jfuse-tests/src/test/java/org/cryptomator/jfuse/tests/MirrorIT.java
@@ -26,6 +26,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -42,17 +44,21 @@ public class MirrorIT {
 		orig = tmpDir.resolve("orig");
 		Files.createDirectories(orig);
 		AbstractMirrorFileSystem fs;
+		List<String> flags = new ArrayList<>();
+		flags.add("-s");
 		if (OS.WINDOWS.isCurrentOs()) {
-			mirror = Path.of("M:");
+			mirror = Path.of("M:\\");
 			Assumptions.assumeTrue(Files.notExists(mirror), "M: drive occupied");
 			fs = new WindowsMirrorFileSystem(orig, builder.errno());
+			flags.add("-ouid=-1");
+			flags.add("-ogid=-1");
 		} else {
 			mirror = tmpDir.resolve("mirror");
 			Files.createDirectories(mirror);
 			fs = new PosixMirrorFileSystem(orig, builder.errno());
 		}
 		fuse = builder.build(fs);
-		int result = fuse.mount("mirror-it", mirror, "-s");
+		int result = fuse.mount("mirror-it", mirror, flags.toArray(String[]::new));
 		Assertions.assertEquals(0, result, "mount failed");
 	}
 

--- a/jfuse-tests/src/test/java/org/cryptomator/jfuse/tests/MirrorIT.java
+++ b/jfuse-tests/src/test/java/org/cryptomator/jfuse/tests/MirrorIT.java
@@ -34,8 +34,6 @@ import java.util.concurrent.TimeoutException;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class MirrorIT {
 
-	private static final String WIN_MOUNT_DIR_PROP = "jfuse.win.integrationMountDir";
-
 	private Path orig;
 	private Path mirror;
 	private Fuse fuse;

--- a/jfuse-win-amd64/src/main/java/org/cryptomator/jfuse/win/amd64/FuseImpl.java
+++ b/jfuse-win-amd64/src/main/java/org/cryptomator/jfuse/win/amd64/FuseImpl.java
@@ -67,6 +67,7 @@ public final class FuseImpl extends Fuse {
 		return fuse_h.fuse_main_real(argc, argv, struct, struct.byteSize(), MemoryAddress.NULL);
 	}
 
+	//TODO: subject to change
 	private void fuseExit() {
 		if (fuseHandle != null) {
 			fuse_h.fuse_exit(fuseHandle);
@@ -224,6 +225,7 @@ public final class FuseImpl extends Fuse {
 		}
 	}
 
+	//TODO: subject to change
 	@Override
 	public void close() throws TimeoutException {
 		fuseExit();

--- a/jfuse-win-amd64/src/main/java/org/cryptomator/jfuse/win/amd64/FuseImpl.java
+++ b/jfuse-win-amd64/src/main/java/org/cryptomator/jfuse/win/amd64/FuseImpl.java
@@ -12,7 +12,9 @@ import org.cryptomator.jfuse.win.amd64.extr.fuse_operations;
 import org.cryptomator.jfuse.win.amd64.extr.fuse_timespec;
 
 import java.nio.ByteBuffer;
+import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
 
 public final class FuseImpl extends Fuse {
 
@@ -43,6 +45,16 @@ public final class FuseImpl extends Fuse {
 			initialized.completeExceptionally(e);
 		}
 		return MemoryAddress.NULL;
+	}
+
+	@Override
+	public int mount(String progName, Path mountPoint, String... flags) throws TimeoutException {
+		var adjustedMP = mountPoint;
+		if (mountPoint.compareTo(mountPoint.getRoot()) == 0 && mountPoint.isAbsolute()) {
+			//winfsp accepts only drive letters written in drive relative notation
+			adjustedMP = Path.of(mountPoint.toString().charAt(0) + ":");
+		}
+		return super.mount(progName, adjustedMP, flags);
 	}
 
 	@Override


### PR DESCRIPTION
This PR:
* updates the windows jfuse implementation to the same state as the mac and linux impl (mount, rund and unmount without errors or exceptions)
* activates the windows mirror integration tests on the CI

Regarding 25603a02f7cdf2e1189a938cec49a196ae3adddb:
Due to the first [failed CI run](https://github.com/cryptomator/jfuse/actions/runs/1999695202) with unclear error message, i thought maybe we have to mount into a directory and prepared everything in the integration test for it. Because I'm messy i forgot to set the property in the ci script, but the tests were successful nonetheless. 🤷 