### PR TITLE
Windows: Poll loop to check if mount is truly done

### DIFF
--- a/jfuse-tests/pom.xml
+++ b/jfuse-tests/pom.xml
@@ -61,6 +61,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
 					<argLine>@{surefire.jacoco.args} -Djava.library.path=@{fuse.lib.path} --enable-native-access=ALL-UNNAMED --enable-preview</argLine>
+					<forkedProcessTimeoutInSeconds>240</forkedProcessTimeoutInSeconds>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/jfuse-tests/pom.xml
+++ b/jfuse-tests/pom.xml
@@ -61,7 +61,6 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
 					<argLine>@{surefire.jacoco.args} -Djava.library.path=@{fuse.lib.path} --enable-native-access=ALL-UNNAMED --enable-preview</argLine>
-					<forkedProcessTimeoutInSeconds>240</forkedProcessTimeoutInSeconds>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/jfuse-tests/src/test/java/org/cryptomator/jfuse/tests/MirrorIT.java
+++ b/jfuse-tests/src/test/java/org/cryptomator/jfuse/tests/MirrorIT.java
@@ -62,7 +62,6 @@ public class MirrorIT {
 		}
 		fuse = builder.build(fs);
 		fuse.mount("mirror-it", mirror, flags.toArray(String[]::new));
-		Thread.sleep(100); // give the file system some time to accept the mounted volume
 	}
 
 	@AfterAll

--- a/jfuse-win-amd64/src/main/java/org/cryptomator/jfuse/win/amd64/FuseImpl.java
+++ b/jfuse-win-amd64/src/main/java/org/cryptomator/jfuse/win/amd64/FuseImpl.java
@@ -63,8 +63,7 @@ public final class FuseImpl extends Fuse {
 		var probe = Files.getFileAttributeView(mountPoint.resolve(MOUNT_PROBE.substring(1)), BasicFileAttributeView.class);
 		while (!accessProbeSuccess.get()) {
 			try {
-				probe.readAttributes();
-				Files.readAttributes(mountPoint, BasicFileAttributes.class);
+				probe.readAttributes(); // we don't care about the result, we just want to trigger a getattr call
 			} catch (IOException e) {
 				//do nothing
 			} finally {


### PR DESCRIPTION
Several times in the past CI tests on Windows failed due for the mount not being ready, although `fuse_init()` was already called.

jfuse uses https://github.com/winfsp/winfsp on Windows and according to its owner, there is no proper way of checking at what point the filesystem is accessible from the outside (see https://github.com/winfsp/winfsp/discussions/440). It was suggested to poll the volume until it successfully returns, but query the volume itself on the one hand requires using the native `CreateFileW` function and on the other admin rights.

The now implemented solution blocks the mount method until the fuse filesystem recieves a `getAttr(...)` call to a specific, hardcoded path.