### PR TITLE
Add `S_IFMT` and `S_ISxxx` predicates

### DIFF
--- a/jfuse-api/src/main/java/org/cryptomator/jfuse/api/Stat.java
+++ b/jfuse-api/src/main/java/org/cryptomator/jfuse/api/Stat.java
@@ -2,45 +2,98 @@ package org.cryptomator.jfuse.api;
 
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.Set;
+import java.util.function.IntPredicate;
 
+/**
+ * Represents the <code>stat</code> struct, which contains file attributes.
+ *
+ * @see <a href="https://man7.org/linux/man-pages/man2/stat.2.html">stat man page</a>
+ * @see <a href="https://man7.org/linux/man-pages/man7/inode.7.html">inode man page</a>
+ */
 @SuppressWarnings("OctalInteger")
 public interface Stat {
+
+	/**
+	 * Bit mask for the file type bit field
+	 */
+	int S_IFMT = 0170000;
 
 	/**
 	 * Mask value for file type socket
 	 * See man page of inode(7).
 	 */
 	int S_IFSOCK = 0140000;
+
 	/**
 	 * Mask value for file type symbolic link
 	 * See man page of inode(7).
 	 */
 	int S_IFLNK = 0120000;
+
 	/**
 	 * Mask value for file type regular file
 	 * See man page of inode(7).
 	 */
 	int S_IFREG = 0100000;
+
 	/**
 	 * Mask value for file type block device
 	 * See man page of inode(7).
 	 */
 	int S_IFBLK = 0060000;
+
 	/**
 	 * Mask value for file type directory
 	 * See man page of inode(7).
 	 */
 	int S_IFDIR = 0040000;
+
 	/**
 	 * Mask value for file type character device
 	 * See man page of inode(7).
 	 */
 	int S_IFCHR = 0020000;
+
 	/**
 	 * Mask value for file type named pipe (FIFO)
 	 * See man page of inode(7).
 	 */
 	int S_IFIFO = 0010000;
+
+	/**
+	 * is it a regular file?
+	 */
+	IntPredicate S_ISREG = m -> (m & S_IFMT) == S_IFREG;
+
+	/**
+	 * directory?
+	 */
+	IntPredicate S_ISDIR = m -> (m & S_IFMT) == S_IFDIR;
+
+	/**
+	 * character device?
+	 */
+	IntPredicate S_ISCHR = m -> (m & S_IFMT) == S_IFCHR;
+
+	/**
+	 * block device?
+	 */
+	IntPredicate S_ISBLK = m -> (m & S_IFMT) == S_IFBLK;
+
+	/**
+	 * FIFO (named pipe)?
+	 */
+	IntPredicate S_ISFIFO = m -> (m & S_IFMT) == S_IFIFO;
+
+	/**
+	 * symbolic link?
+	 */
+	IntPredicate S_ISLNK = m -> (m & S_IFMT) == S_IFLNK;
+
+	/**
+	 * socket?
+	 */
+	IntPredicate S_ISSOCK = m -> (m & S_IFMT) == S_IFSOCK;
 
 	TimeSpec aTime();
 
@@ -80,64 +133,26 @@ public interface Stat {
 		setMode(mode);
 	}
 
-	/**
-	 * @return <code>true</code> if <code>S_IFDIR</code> bit is set in {@link #getMode()}
-	 */
-	default boolean isDir() {
-		return hasMode(S_IFDIR);
-	}
-
-	/**
-	 * Sets the <code>S_IFDIR</code> bit in {@link #setMode(int)}
-	 *
-	 * @param isDir Whether to set the <code>S_IFDIR</code> bit to one.
-	 */
-	default void toggleDir(boolean isDir) {
-		toggleMode(S_IFDIR, isDir);
-	}
-
-	/**
-	 * @return <code>true</code> if <code>S_IFREG</code> bit is set in {@link #getMode()}
-	 */
-	default boolean isReg() {
-		return hasMode(S_IFREG);
-	}
-
-	/**
-	 * Sets the <code>S_IFREG</code> bit in {@link #setMode(int)}
-	 *
-	 * @param isReg Whether to set the <code>S_IFREG</code> bit to one.
-	 */
-	default void toggleReg(boolean isReg) {
-		toggleMode(S_IFREG, isReg);
-	}
-
-	/**
-	 * @return <code>true</code> if <code>S_IFLNK</code> bit is set in {@link #getMode()}
-	 */
-	default boolean isLnk() {
-		return hasMode(S_IFLNK);
-	}
-
-	/**
-	 * Sets the <code>S_IFLNK</code> bit in {@link #setMode(int)}
-	 *
-	 * @param isLnk Whether to set the <code>S_IFLNK</code> bit to one.
-	 */
-	default void toggleLnk(boolean isLnk) {
-		toggleMode(S_IFLNK, isLnk);
-	}
-
 	default boolean hasMode(int mask) {
 		return (getMode() & mask) == mask;
 	}
 
-	default void toggleMode(int mask, boolean set) {
-		if (set) {
-			setMode(getMode() | mask);
-		} else {
-			setMode(getMode() & ~mask);
-		}
+	/**
+	 * Adds the given bit to {@link #getMode() mode}
+	 *
+	 * @param mask the bits to set
+	 */
+	default void setModeBits(int mask) {
+		setMode(getMode() | mask);
+	}
+
+	/**
+	 * Erases the given bit from {@link #getMode() mode}
+	 *
+	 * @param mask the bits to unset
+	 */
+	default void unsetModeBits(int mask) {
+		setMode(getMode() & ~mask);
 	}
 
 }

--- a/jfuse-api/src/test/java/org/cryptomator/jfuse/api/StatTest.java
+++ b/jfuse-api/src/test/java/org/cryptomator/jfuse/api/StatTest.java
@@ -1,101 +1,160 @@
 package org.cryptomator.jfuse.api;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 
-import java.util.stream.Stream;
+import java.nio.file.attribute.PosixFilePermissions;
 
-import static org.cryptomator.jfuse.api.Stat.S_IFDIR;
-import static org.cryptomator.jfuse.api.Stat.S_IFLNK;
-import static org.cryptomator.jfuse.api.Stat.S_IFREG;
+import static org.cryptomator.jfuse.api.Stat.*;
 
+@SuppressWarnings("OctalInteger")
 public class StatTest {
 
 	private static final int MAGIC = 123456;//some rando number
 
 	public Stat stat = Mockito.spy(new StubStatImpl());
 
-	@ParameterizedTest
-	@MethodSource("provideDataForToggle")
-	public void testToggleMode(int mode, int mask, boolean toSet) {
-		Mockito.when(stat.getMode()).thenReturn(mode);
-		stat.toggleMode(mask, toSet);
-		Mockito.verify(stat).setMode(Mockito.intThat(toSet ? hasBitsSet(mask) : hasBitsNotSet(mask)));
+	@Nested
+	@DisplayName("Test File Type Predicates")
+	public class FileTypeTests {
+
+		@Test
+		@DisplayName("neither file mode bit set")
+		public void testNone() {
+			Assertions.assertFalse(Stat.S_ISREG.test(0));
+			Assertions.assertFalse(Stat.S_ISDIR.test(0));
+			Assertions.assertFalse(Stat.S_ISCHR.test(0));
+			Assertions.assertFalse(Stat.S_ISBLK.test(0));
+			Assertions.assertFalse(Stat.S_ISFIFO.test(0));
+			Assertions.assertFalse(Stat.S_ISLNK.test(0));
+			Assertions.assertFalse(Stat.S_ISSOCK.test(0));
+		}
+
+		@ParameterizedTest(name = "S_ISREG({0})")
+		@DisplayName("S_ISREG")
+		@ValueSource(ints = {S_IFREG, S_IFREG | 0755})
+		public void testIsReg(int mode) {
+			Assertions.assertTrue(Stat.S_ISREG.test(mode));
+		}
+
+		@ParameterizedTest(name = "S_ISDIR({0})")
+		@DisplayName("S_ISDIR")
+		@ValueSource(ints = {S_IFDIR, S_IFDIR | 0755})
+		public void testIsDir(int mode) {
+			Assertions.assertTrue(Stat.S_ISDIR.test(mode));
+		}
+
+		@ParameterizedTest(name = "S_ISCHR({0})")
+		@DisplayName("S_ISCHR")
+		@ValueSource(ints = {S_IFCHR, S_IFCHR | 0755})
+		public void testIsChr(int mode) {
+			Assertions.assertTrue(Stat.S_ISCHR.test(mode));
+		}
+
+		@ParameterizedTest(name = "S_ISBLK({0})")
+		@DisplayName("S_ISBLK")
+		@ValueSource(ints = {S_IFBLK, S_IFBLK | 0755})
+		public void testIsBlk(int mode) {
+			Assertions.assertTrue(Stat.S_ISBLK.test(mode));
+		}
+
+		@ParameterizedTest(name = "S_ISFIFO({0})")
+		@DisplayName("S_ISFIFO")
+		@ValueSource(ints = {S_IFIFO, S_IFIFO | 0755})
+		public void testIsFifo(int mode) {
+			Assertions.assertTrue(Stat.S_ISFIFO.test(mode));
+		}
+
+		@ParameterizedTest(name = "S_ISLNK({0})")
+		@DisplayName("S_ISLNK")
+		@ValueSource(ints = {S_IFLNK, S_IFLNK | 0755})
+		public void testIsLnk(int mode) {
+			Assertions.assertTrue(Stat.S_ISLNK.test(mode));
+		}
+
+		@ParameterizedTest(name = "S_ISSOCK({0})")
+		@DisplayName("S_ISSOCK")
+		@ValueSource(ints = {S_IFSOCK, S_IFSOCK | 0755})
+		public void testIsSock(int mode) {
+			Assertions.assertTrue(Stat.S_ISSOCK.test(mode));
+		}
+
 	}
 
-	public static Stream<Arguments> provideDataForToggle() {
-		return Stream.of(
-				Arguments.arguments(S_IFDIR, S_IFDIR, true), //
-				Arguments.arguments(S_IFDIR, S_IFDIR, false), //
-				Arguments.arguments(0, S_IFDIR, true), //
-				Arguments.arguments(0, S_IFDIR, false)
-		);
+	@Nested
+	@DisplayName("permissions")
+	public class Permissions {
+
+		@DisplayName("getPermissions()")
+		@ParameterizedTest(name = "getPermissions({0}) == {1}")
+		@CsvSource(value = {
+				"0755,rwxr-xr-x",
+				"0644,rw-r--r--",
+				"0010644,rw-r--r--"
+		})
+		public void getPermissions(String mode, String perms) {
+			Mockito.when(stat.getMode()).thenReturn(Integer.valueOf(mode, 8));
+			var expected = PosixFilePermissions.fromString(perms);
+
+			var result = stat.getPermissions();
+
+			Assertions.assertEquals(expected, result);
+		}
+
+		@DisplayName("setPermissions()")
+		@ParameterizedTest(name = "setPermissions({1}) == {0}")
+		@CsvSource(value = {
+				"0755,rwxr-xr-x",
+				"0644,rw-r--r--",
+		})
+		public void setPermissions(String mode, String perms) {
+			Mockito.when(stat.getMode()).thenReturn(S_IFDIR);
+			var permissions = PosixFilePermissions.fromString(perms);
+
+			stat.setPermissions(permissions);
+
+			Mockito.verify(stat).setMode(S_IFDIR | Integer.valueOf(mode, 8));
+		}
+
 	}
 
 	@ParameterizedTest
 	@ValueSource(booleans = {true, false})
 	public void testHasMode(boolean isPresent) {
 		Mockito.when(stat.getMode()).thenReturn(isPresent ? MAGIC : ~MAGIC);
+
 		boolean result = stat.hasMode(MAGIC);
+
 		Assertions.assertEquals(isPresent, result);
 	}
 
-
 	@Test
-	public void testIsDir() {
-		stat.isDir();
-		Mockito.verify(stat).hasMode(S_IFDIR);
-	}
+	@DisplayName("setModeBits()")
+	public void testSetModeBits() {
+		Mockito.when(stat.getMode()).thenReturn(0755);
 
-	@ParameterizedTest
-	@ValueSource(booleans = {true, false})
-	public void testToggleDir(boolean isDir) {
-		stat.toggleDir(isDir);
-		Mockito.verify(stat).toggleMode(S_IFDIR, isDir);
+		stat.setModeBits(S_IFDIR);
+
+		Mockito.verify(stat).setMode(S_IFDIR | 0755);
 	}
 
 	@Test
-	public void testIsReg() {
-		stat.isReg();
-		Mockito.verify(stat).hasMode(S_IFREG);
+	@DisplayName("unsetModeBits()")
+	public void testUnsetModeBits() {
+		Mockito.when(stat.getMode()).thenReturn(S_IFDIR | 0755);
+
+		stat.unsetModeBits(S_IFDIR);
+
+		Mockito.verify(stat).setMode(0755);
 	}
 
-	@ParameterizedTest
-	@ValueSource(booleans = {true, false})
-	public void testToggleReg(boolean isReg) {
-		stat.toggleReg(isReg);
-		Mockito.verify(stat).toggleMode(S_IFREG, isReg);
-	}
-
-	@Test
-	public void testIsLnk() {
-		stat.isLnk();
-		Mockito.verify(stat).hasMode(S_IFLNK);
-	}
-
-	@ParameterizedTest
-	@ValueSource(booleans = {true, false})
-	public void testToggleLnk(boolean isLnk) {
-		stat.toggleLnk(isLnk);
-		Mockito.verify(stat).toggleMode(S_IFLNK, isLnk);
-	}
-
-	private static ArgumentMatcher<Integer> hasBitsSet(int mask) {
-		return toMatch -> (toMatch & mask) == mask;
-	}
-
-	private static ArgumentMatcher<Integer> hasBitsNotSet(int mask) {
-		return toMatch -> (toMatch & mask) == 0;
-	}
-
-
-	private class StubStatImpl implements Stat {
+	private static class StubStatImpl implements Stat {
 
 		@Override
 		public TimeSpec aTime() {

--- a/jfuse-examples/src/main/java/org/cryptomator/jfuse/examples/AbstractMirrorFileSystem.java
+++ b/jfuse-examples/src/main/java/org/cryptomator/jfuse/examples/AbstractMirrorFileSystem.java
@@ -194,12 +194,12 @@ public abstract sealed class AbstractMirrorFileSystem implements FuseOperations 
 		stat.setSize(attrs.size());
 		stat.setNLink((short) 1);
 		if (attrs.isDirectory()) {
-			stat.toggleDir(true);
+			stat.setModeBits(Stat.S_IFDIR);
 			stat.setNLink((short) 2); // quick and dirty implementation. should really be 2 + subdir count
 		} else if (attrs.isSymbolicLink()) {
-			stat.toggleLnk(true);
-		} else if (attrs.isRegularFile()){
-			stat.toggleReg(true);
+			stat.setModeBits(Stat.S_IFLNK);
+		} else if (attrs.isRegularFile()) {
+			stat.setModeBits(Stat.S_IFREG);
 		}
 		stat.aTime().set(attrs.lastAccessTime().toInstant());
 		stat.mTime().set(attrs.lastModifiedTime().toInstant());


### PR DESCRIPTION
Trying to be as close to `stat.h` as possible to ease implementation, this adds constants for the [various C makros](https://www.gnu.org/software/libc/manual/html_node/Testing-File-Type.html) such as `S_ISREG`, `S_ISDIR`, ...

This allows us to drop `isReg()`, `toggleReg()` and so on. Btw these never worked correctly, as a link (`0120000`) would have been reported as a regular file (`0100000`) with the old test (`(mode & 0100000) == 0100000`).

This fixes #12.