### PR TITLE
apply mount probe mechanism to all implementations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
 
   mac:
     name: Test jfuse-mac
-    runs-on: macos-12
+    runs-on: macos-10.15
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - uses: actions/checkout@v3
@@ -39,12 +39,9 @@ jobs:
           distribution: 'zulu'
           cache: 'maven'
       - name: Setup fuse
-        run: |
-          brew tap macos-fuse-t/homebrew-cask
-          brew update
-          brew install fuse-t
+        run: brew install macfuse
       - name: Maven build
-        run: mvn -B verify -Dfuse.lib.path="/usr/local/lib/libfuse-t.dylib"
+        run: mvn -B verify -Dfuse.lib.path="/usr/local/lib/libfuse.dylib"
       - uses: actions/upload-artifact@v3
         with:
           name: coverage-mac

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
 
   mac:
     name: Test jfuse-mac
-    runs-on: macos-10.15
+    runs-on: macos-12
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - uses: actions/checkout@v3
@@ -39,9 +39,12 @@ jobs:
           distribution: 'zulu'
           cache: 'maven'
       - name: Setup fuse
-        run: brew install macfuse
+        run: |
+          brew tap macos-fuse-t/homebrew-cask
+          brew update
+          brew install fuse-t
       - name: Maven build
-        run: mvn -B verify -Dfuse.lib.path="/usr/local/lib/libfuse.dylib"
+        run: mvn -B verify -Dfuse.lib.path="/usr/local/lib/libfuse-t.dylib"
       - uses: actions/upload-artifact@v3
         with:
           name: coverage-mac

--- a/jfuse-api/src/main/java/org/cryptomator/jfuse/api/Fuse.java
+++ b/jfuse-api/src/main/java/org/cryptomator/jfuse/api/Fuse.java
@@ -79,6 +79,14 @@ public abstract class Fuse implements AutoCloseable {
 
 	/**
 	 * Registers the callback function for the given operation in the {@code fuse_operations} struct.
+	 * <p>
+	 * Implementers need to make sure to:
+	 * <ol>
+	 *     <li>create an upcall stub for the given operation and save its address at the appropriate position within the
+	 *     {@link #fuseOperationsStruct}</li>
+	 *     <li>the necessary adaption between native and high-level Java types takes place</li>
+	 *     <li>the adapter calls the corresponding function in {@link #fuseOperations}</li>
+	 * </ol>
 	 *
 	 * @param operation Which function
 	 */
@@ -183,7 +191,7 @@ public abstract class Fuse implements AutoCloseable {
 	 * Decorates the {@link FuseOperations#getattr(String, Stat, FileInfo) getattr} call of a FuseOperations object
 	 * in order to detect accesses to {@value MOUNT_PROBE} system during {@link #waitForMountingToComplete(Path)}.
 	 *
-	 * @param delegate The original FuseOperations object
+	 * @param delegate  The original FuseOperations object
 	 * @param onObserve Handler to invoke as soon as the desired call is detected
 	 */
 	private record MountProbeObserver(FuseOperations delegate, Runnable onObserve) implements FuseOperationsDecorator {

--- a/jfuse-api/src/main/java/org/cryptomator/jfuse/api/Fuse.java
+++ b/jfuse-api/src/main/java/org/cryptomator/jfuse/api/Fuse.java
@@ -65,6 +65,7 @@ public abstract class Fuse implements AutoCloseable {
 	protected Fuse(FuseOperations fuseOperations, Function<SegmentAllocator, MemorySegment> structAllocator) {
 		this.fuseOperations = fuseOperations;
 		this.segment = structAllocator.apply(fuseScope);
+		fuseOperations.supportedOperations().forEach(this::bind);
 	}
 
 	/**
@@ -75,6 +76,13 @@ public abstract class Fuse implements AutoCloseable {
 	public static FuseBuilder builder() {
 		return FuseBuilder.getSupported();
 	}
+
+	/**
+	 * Registers the callback function for the given operation in the {@code fuse_operations} struct.
+	 *
+	 * @param operation Which function
+	 */
+	protected abstract void bind(FuseOperations.Operation operation);
 
 	/**
 	 * Mounts this fuse file system at the given mount point.

--- a/jfuse-api/src/main/java/org/cryptomator/jfuse/api/Fuse.java
+++ b/jfuse-api/src/main/java/org/cryptomator/jfuse/api/Fuse.java
@@ -63,7 +63,7 @@ public abstract class Fuse implements AutoCloseable {
 	 * @param fuseOperations The file system operations
 	 */
 	protected Fuse(FuseOperations fuseOperations, Function<SegmentAllocator, MemorySegment> structAllocator) {
-		this.fuseOperations = fuseOperations;
+		this.fuseOperations = new MountProbeObserver(fuseOperations, mountProbeSucceeded::countDown);
 		this.fuseOperationsStruct = structAllocator.apply(fuseScope);
 		fuseOperations.supportedOperations().forEach(this::bind);
 	}
@@ -144,22 +144,6 @@ public abstract class Fuse implements AutoCloseable {
 	}
 
 	/**
-	 * Decorates {@link FuseOperations#getattr(String, Stat, FileInfo)} and ensures to properly handle mount probing.
-	 *
-	 * @param path File path
-	 * @param stat File attributes
-	 * @param fi   File handle
-	 * @return 0 on success or negated error code
-	 */
-	@MustBeInvokedByOverriders
-	protected int getattr(String path, Stat stat, @Nullable FileInfo fi) {
-		if (mountProbeSucceeded.getCount() > 0 && path.equals(MOUNT_PROBE)) {
-			mountProbeSucceeded.countDown();
-		}
-		return fuseOperations.getattr(path, stat, fi);
-	}
-
-	/**
 	 * Mounts the fuse file system.
 	 *
 	 * @param args Mount args
@@ -192,6 +176,24 @@ public abstract class Fuse implements AutoCloseable {
 			Thread.currentThread().interrupt();
 		} finally {
 			fuseScope.close();
+		}
+	}
+
+	/**
+	 * Decorates the {@link FuseOperations#getattr(String, Stat, FileInfo) getattr} call of a FuseOperations object
+	 * in order to detect accesses to {@value MOUNT_PROBE} system during {@link #waitForMountingToComplete(Path)}.
+	 *
+	 * @param delegate The original FuseOperations object
+	 * @param onObserve Handler to invoke as soon as the desired call is detected
+	 */
+	private record MountProbeObserver(FuseOperations delegate, Runnable onObserve) implements FuseOperationsDecorator {
+
+		@Override
+		public int getattr(String path, Stat stat, @Nullable FileInfo fi) {
+			if (MOUNT_PROBE.equals(path)) {
+				onObserve.run();
+			}
+			return delegate.getattr(path, stat, fi);
 		}
 	}
 

--- a/jfuse-api/src/main/java/org/cryptomator/jfuse/api/Fuse.java
+++ b/jfuse-api/src/main/java/org/cryptomator/jfuse/api/Fuse.java
@@ -51,7 +51,7 @@ public abstract class Fuse implements AutoCloseable {
 	/**
 	 * The memory segment containing the fuse_operations struct.
 	 */
-	protected final MemorySegment segment;
+	protected final MemorySegment fuseOperationsStruct;
 
 	private final AtomicReference<FuseMount> mount = new AtomicReference<>(UNMOUNTED);
 	private final ExecutorService executor = Executors.newSingleThreadExecutor(THREAD_FACTORY);
@@ -64,7 +64,7 @@ public abstract class Fuse implements AutoCloseable {
 	 */
 	protected Fuse(FuseOperations fuseOperations, Function<SegmentAllocator, MemorySegment> structAllocator) {
 		this.fuseOperations = fuseOperations;
-		this.segment = structAllocator.apply(fuseScope);
+		this.fuseOperationsStruct = structAllocator.apply(fuseScope);
 		fuseOperations.supportedOperations().forEach(this::bind);
 	}
 

--- a/jfuse-api/src/test/java/org/cryptomator/jfuse/api/FuseTest.java
+++ b/jfuse-api/src/test/java/org/cryptomator/jfuse/api/FuseTest.java
@@ -1,0 +1,72 @@
+package org.cryptomator.jfuse.api;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.spi.FileSystemProvider;
+import java.time.Duration;
+import java.util.List;
+
+public class FuseTest {
+
+	private FuseOperations fuseOps = Mockito.mock(FuseOperations.class);
+	private Fuse fuse = Mockito.spy(new FuseStub(fuseOps));
+
+	@Test
+	@DisplayName("waitForMountingToComplete() waits for getattr(\"/jfuse_windows_mount_probe\")")
+	public void testWaitForMountingToComplete() throws IOException {
+		Path mountPoint = Mockito.mock(Path.class, "/mnt");
+		Path probePath = Mockito.mock(Path.class, "/mnt/jfuse_windows_mount_probe");
+		FileSystem fs = Mockito.mock(FileSystem.class);
+		FileSystemProvider fsProv = Mockito.mock(FileSystemProvider.class);
+		BasicFileAttributeView attrView = Mockito.mock(BasicFileAttributeView.class);
+		Mockito.doReturn(probePath).when(mountPoint).resolve("jfuse_mount_probe");
+		Mockito.doReturn(fs).when(probePath).getFileSystem();
+		Mockito.doReturn(fsProv).when(fs).provider();
+		Mockito.doReturn(attrView).when(fsProv).getFileAttributeView(probePath, BasicFileAttributeView.class);
+		Mockito.doAnswer(invocation -> {
+			fuse.getattr("/jfuse_mount_probe", Mockito.mock(Stat.class), Mockito.mock(FileInfo.class));
+			throw new NoSuchFileException("/mnt/jfuse_mount_probe not found");
+		}).when(attrView).readAttributes();
+
+		Assertions.assertTimeoutPreemptively(Duration.ofSeconds(1), () -> fuse.waitForMountingToComplete(mountPoint));
+
+		Mockito.verify(fuseOps).getattr(Mockito.eq("/jfuse_mount_probe"), Mockito.any(), Mockito.any());
+	}
+
+	private static class FuseStub extends Fuse {
+
+		protected FuseStub(FuseOperations fuseOperations) {
+			super(fuseOperations);
+		}
+
+		@Override
+		protected FuseMount mount(List<String> args) {
+			return new FuseMount() {
+
+				@Override
+				public int loop() {
+					return 0;
+				}
+
+				@Override
+				public void unmount() {
+					// no-op
+				}
+
+				@Override
+				public void destroy() {
+					// no-op
+				}
+			};
+		}
+	}
+
+}

--- a/jfuse-api/src/test/java/org/cryptomator/jfuse/api/FuseTest.java
+++ b/jfuse-api/src/test/java/org/cryptomator/jfuse/api/FuseTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
-import java.lang.foreign.ValueLayout;
 import java.nio.file.FileSystem;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
@@ -37,7 +36,7 @@ public class FuseTest {
 			throw new NoSuchFileException("/mnt/jfuse_mount_probe not found");
 		}).doAnswer(invocation -> {
 			// second attempt: simulate hitting getattr
-			fuse.fuseOperations.getattr("/jfuse_mount_probe", Mockito.mock(Stat.class), Mockito.mock(FileInfo.class));
+			fuse.delegate.getattr("/jfuse_mount_probe", Mockito.mock(Stat.class), Mockito.mock(FileInfo.class));
 			throw new NoSuchFileException("/mnt/jfuse_mount_probe still not found");
 		}).when(attrView).readAttributes();
 

--- a/jfuse-api/src/test/java/org/cryptomator/jfuse/api/FuseTest.java
+++ b/jfuse-api/src/test/java/org/cryptomator/jfuse/api/FuseTest.java
@@ -33,7 +33,7 @@ public class FuseTest {
 		Mockito.doReturn(fsProv).when(fs).provider();
 		Mockito.doReturn(attrView).when(fsProv).getFileAttributeView(probePath, BasicFileAttributeView.class);
 		Mockito.doAnswer(invocation -> {
-			fuse.getattr("/jfuse_mount_probe", Mockito.mock(Stat.class), Mockito.mock(FileInfo.class));
+			fuse.fuseOperations.getattr("/jfuse_mount_probe", Mockito.mock(Stat.class), Mockito.mock(FileInfo.class));
 			throw new NoSuchFileException("/mnt/jfuse_mount_probe not found");
 		}).when(attrView).readAttributes();
 

--- a/jfuse-api/src/test/java/org/cryptomator/jfuse/api/FuseTest.java
+++ b/jfuse-api/src/test/java/org/cryptomator/jfuse/api/FuseTest.java
@@ -49,6 +49,11 @@ public class FuseTest {
 		}
 
 		@Override
+		protected void bind(FuseOperations.Operation operation) {
+			// no-op
+		}
+
+		@Override
 		protected FuseMount mount(List<String> args) {
 			return new FuseMount() {
 

--- a/jfuse-api/src/test/java/org/cryptomator/jfuse/api/FuseTest.java
+++ b/jfuse-api/src/test/java/org/cryptomator/jfuse/api/FuseTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.lang.foreign.ValueLayout;
 import java.nio.file.FileSystem;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
@@ -44,7 +45,7 @@ public class FuseTest {
 	private static class FuseStub extends Fuse {
 
 		protected FuseStub(FuseOperations fuseOperations) {
-			super(fuseOperations);
+			super(fuseOperations, allocator -> allocator.allocate(0L));
 		}
 
 		@Override

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/FuseImpl.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/FuseImpl.java
@@ -25,7 +25,6 @@ final class FuseImpl extends Fuse {
 
 	public FuseImpl(FuseOperations fuseOperations) {
 		super(fuseOperations, fuse_operations::allocate);
-		fuseOperations.supportedOperations().forEach(this::bind);
 	}
 
 	@Override
@@ -67,7 +66,8 @@ final class FuseImpl extends Fuse {
 		return new FuseArgs(args, opts);
 	}
 
-	private void bind(FuseOperations.Operation operation) {
+	@Override
+	protected void bind(FuseOperations.Operation operation) {
 		switch (operation) {
 			case INIT -> fuse_operations.init$set(segment, fuse_operations.init.allocate(this::init, fuseScope).address());
 			case ACCESS -> fuse_operations.access$set(segment, fuse_operations.access.allocate(this::access, fuseScope).address());

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/FuseImpl.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/FuseImpl.java
@@ -23,11 +23,8 @@ import java.util.List;
 
 final class FuseImpl extends Fuse {
 
-	private final MemorySegment segment;
-
 	public FuseImpl(FuseOperations fuseOperations) {
-		super(fuseOperations);
-		this.segment = fuse_operations.allocate(fuseScope);
+		super(fuseOperations, fuse_operations::allocate);
 		fuseOperations.supportedOperations().forEach(this::bind);
 	}
 

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/FuseImpl.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/FuseImpl.java
@@ -159,7 +159,7 @@ final class FuseImpl extends Fuse {
 
 	private int getattr(MemoryAddress path, MemoryAddress stat, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return this.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
+			return fuseOperations.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
 		}
 	}
 

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/FuseImpl.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/FuseImpl.java
@@ -30,7 +30,7 @@ final class FuseImpl extends Fuse {
 	@Override
 	protected FuseMount mount(List<String> args) throws MountFailedException {
 		var fuseArgs = parseArgs(args);
-		var fuse = fuse_h.fuse_new(fuseArgs.args(), fuseOperationsStruct, fuseOperationsStruct.byteSize(), MemoryAddress.NULL);
+		var fuse = fuse_h.fuse_new(fuseArgs.args(), fuseOps, fuseOps.byteSize(), MemoryAddress.NULL);
 		if (MemoryAddress.NULL.equals(fuse)) {
 			throw new MountFailedException("fuse_new failed");
 		}
@@ -69,32 +69,32 @@ final class FuseImpl extends Fuse {
 	@Override
 	protected void bind(FuseOperations.Operation operation) {
 		switch (operation) {
-			case INIT -> fuse_operations.init$set(fuseOperationsStruct, fuse_operations.init.allocate(this::init, fuseScope).address());
-			case ACCESS -> fuse_operations.access$set(fuseOperationsStruct, fuse_operations.access.allocate(this::access, fuseScope).address());
-			case CHMOD -> fuse_operations.chmod$set(fuseOperationsStruct, fuse_operations.chmod.allocate(this::chmod, fuseScope).address());
-			case CHOWN -> fuse_operations.chown$set(fuseOperationsStruct, fuse_operations.chown.allocate(this::chown, fuseScope).address());
-			case CREATE -> fuse_operations.create$set(fuseOperationsStruct, fuse_operations.create.allocate(this::create, fuseScope).address());
-			case DESTROY -> fuse_operations.destroy$set(fuseOperationsStruct, fuse_operations.destroy.allocate(this::destroy, fuseScope).address());
-			case FLUSH -> fuse_operations.flush$set(fuseOperationsStruct, fuse_operations.flush.allocate(this::flush, fuseScope).address());
-			case FSYNC -> fuse_operations.fsync$set(fuseOperationsStruct, fuse_operations.fsync.allocate(this::fsync, fuseScope).address());
-			case FSYNCDIR -> fuse_operations.fsyncdir$set(fuseOperationsStruct, fuse_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
-			case GET_ATTR -> fuse_operations.getattr$set(fuseOperationsStruct, fuse_operations.getattr.allocate(this::getattr, fuseScope).address());
-			case MKDIR -> fuse_operations.mkdir$set(fuseOperationsStruct, fuse_operations.mkdir.allocate(this::mkdir, fuseScope).address());
-			case OPEN -> fuse_operations.open$set(fuseOperationsStruct, fuse_operations.open.allocate(this::open, fuseScope).address());
-			case OPEN_DIR -> fuse_operations.opendir$set(fuseOperationsStruct, fuse_operations.opendir.allocate(this::opendir, fuseScope).address());
-			case READ -> fuse_operations.read$set(fuseOperationsStruct, fuse_operations.read.allocate(this::read, fuseScope).address());
-			case READ_DIR -> fuse_operations.readdir$set(fuseOperationsStruct, fuse_operations.readdir.allocate(this::readdir, fuseScope).address());
-			case READLINK -> fuse_operations.readlink$set(fuseOperationsStruct, fuse_operations.readlink.allocate(this::readlink, fuseScope).address());
-			case RELEASE -> fuse_operations.release$set(fuseOperationsStruct, fuse_operations.release.allocate(this::release, fuseScope).address());
-			case RELEASE_DIR -> fuse_operations.releasedir$set(fuseOperationsStruct, fuse_operations.releasedir.allocate(this::releasedir, fuseScope).address());
-			case RENAME -> fuse_operations.rename$set(fuseOperationsStruct, fuse_operations.rename.allocate(this::rename, fuseScope).address());
-			case RMDIR -> fuse_operations.rmdir$set(fuseOperationsStruct, fuse_operations.rmdir.allocate(this::rmdir, fuseScope).address());
-			case STATFS -> fuse_operations.statfs$set(fuseOperationsStruct, fuse_operations.statfs.allocate(this::statfs, fuseScope).address());
-			case SYMLINK -> fuse_operations.symlink$set(fuseOperationsStruct, fuse_operations.symlink.allocate(this::symlink, fuseScope).address());
-			case TRUNCATE -> fuse_operations.truncate$set(fuseOperationsStruct, fuse_operations.truncate.allocate(this::truncate, fuseScope).address());
-			case UNLINK -> fuse_operations.unlink$set(fuseOperationsStruct, fuse_operations.unlink.allocate(this::unlink, fuseScope).address());
-			case UTIMENS -> fuse_operations.utimens$set(fuseOperationsStruct, fuse_operations.utimens.allocate(this::utimens, fuseScope).address());
-			case WRITE -> fuse_operations.write$set(fuseOperationsStruct, fuse_operations.write.allocate(this::write, fuseScope).address());
+			case INIT -> fuse_operations.init$set(fuseOps, fuse_operations.init.allocate(this::init, fuseScope).address());
+			case ACCESS -> fuse_operations.access$set(fuseOps, fuse_operations.access.allocate(this::access, fuseScope).address());
+			case CHMOD -> fuse_operations.chmod$set(fuseOps, fuse_operations.chmod.allocate(this::chmod, fuseScope).address());
+			case CHOWN -> fuse_operations.chown$set(fuseOps, fuse_operations.chown.allocate(this::chown, fuseScope).address());
+			case CREATE -> fuse_operations.create$set(fuseOps, fuse_operations.create.allocate(this::create, fuseScope).address());
+			case DESTROY -> fuse_operations.destroy$set(fuseOps, fuse_operations.destroy.allocate(this::destroy, fuseScope).address());
+			case FLUSH -> fuse_operations.flush$set(fuseOps, fuse_operations.flush.allocate(this::flush, fuseScope).address());
+			case FSYNC -> fuse_operations.fsync$set(fuseOps, fuse_operations.fsync.allocate(this::fsync, fuseScope).address());
+			case FSYNCDIR -> fuse_operations.fsyncdir$set(fuseOps, fuse_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
+			case GET_ATTR -> fuse_operations.getattr$set(fuseOps, fuse_operations.getattr.allocate(this::getattr, fuseScope).address());
+			case MKDIR -> fuse_operations.mkdir$set(fuseOps, fuse_operations.mkdir.allocate(this::mkdir, fuseScope).address());
+			case OPEN -> fuse_operations.open$set(fuseOps, fuse_operations.open.allocate(this::open, fuseScope).address());
+			case OPEN_DIR -> fuse_operations.opendir$set(fuseOps, fuse_operations.opendir.allocate(this::opendir, fuseScope).address());
+			case READ -> fuse_operations.read$set(fuseOps, fuse_operations.read.allocate(this::read, fuseScope).address());
+			case READ_DIR -> fuse_operations.readdir$set(fuseOps, fuse_operations.readdir.allocate(this::readdir, fuseScope).address());
+			case READLINK -> fuse_operations.readlink$set(fuseOps, fuse_operations.readlink.allocate(this::readlink, fuseScope).address());
+			case RELEASE -> fuse_operations.release$set(fuseOps, fuse_operations.release.allocate(this::release, fuseScope).address());
+			case RELEASE_DIR -> fuse_operations.releasedir$set(fuseOps, fuse_operations.releasedir.allocate(this::releasedir, fuseScope).address());
+			case RENAME -> fuse_operations.rename$set(fuseOps, fuse_operations.rename.allocate(this::rename, fuseScope).address());
+			case RMDIR -> fuse_operations.rmdir$set(fuseOps, fuse_operations.rmdir.allocate(this::rmdir, fuseScope).address());
+			case STATFS -> fuse_operations.statfs$set(fuseOps, fuse_operations.statfs.allocate(this::statfs, fuseScope).address());
+			case SYMLINK -> fuse_operations.symlink$set(fuseOps, fuse_operations.symlink.allocate(this::symlink, fuseScope).address());
+			case TRUNCATE -> fuse_operations.truncate$set(fuseOps, fuse_operations.truncate.allocate(this::truncate, fuseScope).address());
+			case UNLINK -> fuse_operations.unlink$set(fuseOps, fuse_operations.unlink.allocate(this::unlink, fuseScope).address());
+			case UTIMENS -> fuse_operations.utimens$set(fuseOps, fuse_operations.utimens.allocate(this::utimens, fuseScope).address());
+			case WRITE -> fuse_operations.write$set(fuseOps, fuse_operations.write.allocate(this::write, fuseScope).address());
 		}
 	}
 
@@ -104,140 +104,140 @@ final class FuseImpl extends Fuse {
 			var connInfo = new FuseConnInfoImpl(conn, scope);
 			connInfo.setWant(connInfo.want() | FuseConnInfo.FUSE_CAP_READDIRPLUS);
 			var config = new FuseConfigImpl(cfg, scope);
-			fuseOperations.init(connInfo, config);
+			delegate.init(connInfo, config);
 		}
 		return MemoryAddress.NULL;
 	}
 
 	private int access(MemoryAddress path, int mask) {
-		return fuseOperations.access(path.getUtf8String(0), mask);
+		return delegate.access(path.getUtf8String(0), mask);
 	}
 
 	private int chmod(MemoryAddress path, int mode, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.chmod(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
+			return delegate.chmod(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	@VisibleForTesting
 	int chown(MemoryAddress path, int uid, int gid, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.chown(path.getUtf8String(0), uid, gid, new FileInfoImpl(fi, scope));
+			return delegate.chown(path.getUtf8String(0), uid, gid, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int create(MemoryAddress path, int mode, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.create(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
+			return delegate.create(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private void destroy(MemoryAddress addr) {
-		fuseOperations.destroy();
+		delegate.destroy();
 	}
 
 	@VisibleForTesting
 	int flush(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.flush(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return delegate.flush(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	@VisibleForTesting
 	int fsync(MemoryAddress path, int datasync, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.fsync(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
+			return delegate.fsync(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	@VisibleForTesting
 	int fsyncdir(MemoryAddress path, int datasync, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.fsyncdir(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
+			return delegate.fsyncdir(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int getattr(MemoryAddress path, MemoryAddress stat, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
+			return delegate.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int mkdir(MemoryAddress path, int mode) {
-		return fuseOperations.mkdir(path.getUtf8String(0), mode);
+		return delegate.mkdir(path.getUtf8String(0), mode);
 	}
 
 	private int open(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.open(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return delegate.open(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int opendir(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.opendir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return delegate.opendir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int read(MemoryAddress path, MemoryAddress buf, long size, long offset, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
 			var buffer = MemorySegment.ofAddress(buf, size, scope).asByteBuffer();
-			return fuseOperations.read(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
+			return delegate.read(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int readdir(MemoryAddress path, MemoryAddress buf, MemoryAddress filler, long offset, MemoryAddress fi, int flags) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.readdir(path.getUtf8String(0), new DirFillerImpl(buf, filler, scope), offset, new FileInfoImpl(fi, scope), flags);
+			return delegate.readdir(path.getUtf8String(0), new DirFillerImpl(buf, filler, scope), offset, new FileInfoImpl(fi, scope), flags);
 		}
 	}
 
 	private int readlink(MemoryAddress path, MemoryAddress buf, long len) {
 		try (var scope = MemorySession.openConfined()) {
 			var buffer = MemorySegment.ofAddress(buf, len, scope).asByteBuffer();
-			return fuseOperations.readlink(path.getUtf8String(0), buffer, len);
+			return delegate.readlink(path.getUtf8String(0), buffer, len);
 		}
 	}
 
 	private int release(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.release(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return delegate.release(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int releasedir(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.releasedir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return delegate.releasedir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int rename(MemoryAddress oldpath, MemoryAddress newpath, int flags) {
-		return fuseOperations.rename(oldpath.getUtf8String(0), newpath.getUtf8String(0), flags);
+		return delegate.rename(oldpath.getUtf8String(0), newpath.getUtf8String(0), flags);
 	}
 
 	private int rmdir(MemoryAddress path) {
-		return fuseOperations.rmdir(path.getUtf8String(0));
+		return delegate.rmdir(path.getUtf8String(0));
 	}
 
 	private int statfs(MemoryAddress path, MemoryAddress statvfs) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.statfs(path.getUtf8String(0), new StatvfsImpl(statvfs, scope));
+			return delegate.statfs(path.getUtf8String(0), new StatvfsImpl(statvfs, scope));
 		}
 	}
 
 	private int symlink(MemoryAddress linkname, MemoryAddress target) {
-		return fuseOperations.symlink(linkname.getUtf8String(0), target.getUtf8String(0));
+		return delegate.symlink(linkname.getUtf8String(0), target.getUtf8String(0));
 	}
 
 	private int truncate(MemoryAddress path, long size, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.truncate(path.getUtf8String(0), size, new FileInfoImpl(fi, scope));
+			return delegate.truncate(path.getUtf8String(0), size, new FileInfoImpl(fi, scope));
 		}
 	}
 
 
 	private int unlink(MemoryAddress path) {
-		return fuseOperations.unlink(path.getUtf8String(0));
+		return delegate.unlink(path.getUtf8String(0));
 	}
 
 	@VisibleForTesting
@@ -249,13 +249,13 @@ final class FuseImpl extends Fuse {
 				timespec.tv_sec$set(segment, 0);
 				timespec.tv_nsec$set(segment, stat_h.UTIME_NOW());
 				var time = new TimeSpecImpl(segment);
-				return fuseOperations.utimens(path.getUtf8String(0), time, time, new FileInfoImpl(fi, scope));
+				return delegate.utimens(path.getUtf8String(0), time, time, new FileInfoImpl(fi, scope));
 			} else {
 				var seq = MemoryLayout.sequenceLayout(2, timespec.$LAYOUT());
 				var segment = MemorySegment.ofAddress(times, seq.byteSize(), scope);
 				var time0 = segment.asSlice(0, timespec.$LAYOUT().byteSize());
 				var time1 = segment.asSlice(timespec.$LAYOUT().byteSize(), timespec.$LAYOUT().byteSize());
-				return fuseOperations.utimens(path.getUtf8String(0), new TimeSpecImpl(time0), new TimeSpecImpl(time1), new FileInfoImpl(fi, scope));
+				return delegate.utimens(path.getUtf8String(0), new TimeSpecImpl(time0), new TimeSpecImpl(time1), new FileInfoImpl(fi, scope));
 			}
 		}
 	}
@@ -263,7 +263,7 @@ final class FuseImpl extends Fuse {
 	private int write(MemoryAddress path, MemoryAddress buf, long size, long offset, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
 			var buffer = MemorySegment.ofAddress(buf, size, scope).asByteBuffer();
-			return fuseOperations.write(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
+			return delegate.write(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
 		}
 	}
 

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/FuseImpl.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/FuseImpl.java
@@ -6,9 +6,9 @@ import org.cryptomator.jfuse.api.FuseMount;
 import org.cryptomator.jfuse.api.FuseOperations;
 import org.cryptomator.jfuse.api.MountFailedException;
 import org.cryptomator.jfuse.linux.aarch64.extr.fuse_args;
+import org.cryptomator.jfuse.linux.aarch64.extr.fuse_cmdline_opts;
 import org.cryptomator.jfuse.linux.aarch64.extr.fuse_h;
 import org.cryptomator.jfuse.linux.aarch64.extr.fuse_operations;
-import org.cryptomator.jfuse.linux.aarch64.extr.fuse_cmdline_opts;
 import org.cryptomator.jfuse.linux.aarch64.extr.stat_h;
 import org.cryptomator.jfuse.linux.aarch64.extr.timespec;
 import org.jetbrains.annotations.VisibleForTesting;
@@ -23,19 +23,18 @@ import java.util.List;
 
 final class FuseImpl extends Fuse {
 
-	private final FuseOperations delegate;
-	private final MemorySegment fuseOps;
+	private final MemorySegment segment;
 
 	public FuseImpl(FuseOperations fuseOperations) {
-		this.fuseOps = fuse_operations.allocate(fuseScope);
-		this.delegate = fuseOperations;
+		super(fuseOperations);
+		this.segment = fuse_operations.allocate(fuseScope);
 		fuseOperations.supportedOperations().forEach(this::bind);
 	}
 
 	@Override
 	protected FuseMount mount(List<String> args) throws MountFailedException {
 		var fuseArgs = parseArgs(args);
-		var fuse = fuse_h.fuse_new(fuseArgs.args(), fuseOps, fuseOps.byteSize(), MemoryAddress.NULL);
+		var fuse = fuse_h.fuse_new(fuseArgs.args(), segment, segment.byteSize(), MemoryAddress.NULL);
 		if (MemoryAddress.NULL.equals(fuse)) {
 			throw new MountFailedException("fuse_new failed");
 		}
@@ -73,32 +72,32 @@ final class FuseImpl extends Fuse {
 
 	private void bind(FuseOperations.Operation operation) {
 		switch (operation) {
-			case INIT -> fuse_operations.init$set(fuseOps, fuse_operations.init.allocate(this::init, fuseScope).address());
-			case ACCESS -> fuse_operations.access$set(fuseOps, fuse_operations.access.allocate(this::access, fuseScope).address());
-			case CHMOD -> fuse_operations.chmod$set(fuseOps, fuse_operations.chmod.allocate(this::chmod, fuseScope).address());
-			case CHOWN -> fuse_operations.chown$set(fuseOps, fuse_operations.chown.allocate(this::chown, fuseScope).address());
-			case CREATE -> fuse_operations.create$set(fuseOps, fuse_operations.create.allocate(this::create, fuseScope).address());
-			case DESTROY -> fuse_operations.destroy$set(fuseOps, fuse_operations.destroy.allocate(this::destroy, fuseScope).address());
-			case FLUSH -> fuse_operations.flush$set(fuseOps, fuse_operations.flush.allocate(this::flush, fuseScope).address());
-			case FSYNC -> fuse_operations.fsync$set(fuseOps, fuse_operations.fsync.allocate(this::fsync, fuseScope).address());
-			case FSYNCDIR -> fuse_operations.fsyncdir$set(fuseOps, fuse_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
-			case GET_ATTR -> fuse_operations.getattr$set(fuseOps, fuse_operations.getattr.allocate(this::getattr, fuseScope).address());
-			case MKDIR -> fuse_operations.mkdir$set(fuseOps, fuse_operations.mkdir.allocate(this::mkdir, fuseScope).address());
-			case OPEN -> fuse_operations.open$set(fuseOps, fuse_operations.open.allocate(this::open, fuseScope).address());
-			case OPEN_DIR -> fuse_operations.opendir$set(fuseOps, fuse_operations.opendir.allocate(this::opendir, fuseScope).address());
-			case READ -> fuse_operations.read$set(fuseOps, fuse_operations.read.allocate(this::read, fuseScope).address());
-			case READ_DIR -> fuse_operations.readdir$set(fuseOps, fuse_operations.readdir.allocate(this::readdir, fuseScope).address());
-			case READLINK -> fuse_operations.readlink$set(fuseOps, fuse_operations.readlink.allocate(this::readlink, fuseScope).address());
-			case RELEASE -> fuse_operations.release$set(fuseOps, fuse_operations.release.allocate(this::release, fuseScope).address());
-			case RELEASE_DIR -> fuse_operations.releasedir$set(fuseOps, fuse_operations.releasedir.allocate(this::releasedir, fuseScope).address());
-			case RENAME -> fuse_operations.rename$set(fuseOps, fuse_operations.rename.allocate(this::rename, fuseScope).address());
-			case RMDIR -> fuse_operations.rmdir$set(fuseOps, fuse_operations.rmdir.allocate(this::rmdir, fuseScope).address());
-			case STATFS -> fuse_operations.statfs$set(fuseOps, fuse_operations.statfs.allocate(this::statfs, fuseScope).address());
-			case SYMLINK -> fuse_operations.symlink$set(fuseOps, fuse_operations.symlink.allocate(this::symlink, fuseScope).address());
-			case TRUNCATE -> fuse_operations.truncate$set(fuseOps, fuse_operations.truncate.allocate(this::truncate, fuseScope).address());
-			case UNLINK -> fuse_operations.unlink$set(fuseOps, fuse_operations.unlink.allocate(this::unlink, fuseScope).address());
-			case UTIMENS -> fuse_operations.utimens$set(fuseOps, fuse_operations.utimens.allocate(this::utimens, fuseScope).address());
-			case WRITE -> fuse_operations.write$set(fuseOps, fuse_operations.write.allocate(this::write, fuseScope).address());
+			case INIT -> fuse_operations.init$set(segment, fuse_operations.init.allocate(this::init, fuseScope).address());
+			case ACCESS -> fuse_operations.access$set(segment, fuse_operations.access.allocate(this::access, fuseScope).address());
+			case CHMOD -> fuse_operations.chmod$set(segment, fuse_operations.chmod.allocate(this::chmod, fuseScope).address());
+			case CHOWN -> fuse_operations.chown$set(segment, fuse_operations.chown.allocate(this::chown, fuseScope).address());
+			case CREATE -> fuse_operations.create$set(segment, fuse_operations.create.allocate(this::create, fuseScope).address());
+			case DESTROY -> fuse_operations.destroy$set(segment, fuse_operations.destroy.allocate(this::destroy, fuseScope).address());
+			case FLUSH -> fuse_operations.flush$set(segment, fuse_operations.flush.allocate(this::flush, fuseScope).address());
+			case FSYNC -> fuse_operations.fsync$set(segment, fuse_operations.fsync.allocate(this::fsync, fuseScope).address());
+			case FSYNCDIR -> fuse_operations.fsyncdir$set(segment, fuse_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
+			case GET_ATTR -> fuse_operations.getattr$set(segment, fuse_operations.getattr.allocate(this::getattr, fuseScope).address());
+			case MKDIR -> fuse_operations.mkdir$set(segment, fuse_operations.mkdir.allocate(this::mkdir, fuseScope).address());
+			case OPEN -> fuse_operations.open$set(segment, fuse_operations.open.allocate(this::open, fuseScope).address());
+			case OPEN_DIR -> fuse_operations.opendir$set(segment, fuse_operations.opendir.allocate(this::opendir, fuseScope).address());
+			case READ -> fuse_operations.read$set(segment, fuse_operations.read.allocate(this::read, fuseScope).address());
+			case READ_DIR -> fuse_operations.readdir$set(segment, fuse_operations.readdir.allocate(this::readdir, fuseScope).address());
+			case READLINK -> fuse_operations.readlink$set(segment, fuse_operations.readlink.allocate(this::readlink, fuseScope).address());
+			case RELEASE -> fuse_operations.release$set(segment, fuse_operations.release.allocate(this::release, fuseScope).address());
+			case RELEASE_DIR -> fuse_operations.releasedir$set(segment, fuse_operations.releasedir.allocate(this::releasedir, fuseScope).address());
+			case RENAME -> fuse_operations.rename$set(segment, fuse_operations.rename.allocate(this::rename, fuseScope).address());
+			case RMDIR -> fuse_operations.rmdir$set(segment, fuse_operations.rmdir.allocate(this::rmdir, fuseScope).address());
+			case STATFS -> fuse_operations.statfs$set(segment, fuse_operations.statfs.allocate(this::statfs, fuseScope).address());
+			case SYMLINK -> fuse_operations.symlink$set(segment, fuse_operations.symlink.allocate(this::symlink, fuseScope).address());
+			case TRUNCATE -> fuse_operations.truncate$set(segment, fuse_operations.truncate.allocate(this::truncate, fuseScope).address());
+			case UNLINK -> fuse_operations.unlink$set(segment, fuse_operations.unlink.allocate(this::unlink, fuseScope).address());
+			case UTIMENS -> fuse_operations.utimens$set(segment, fuse_operations.utimens.allocate(this::utimens, fuseScope).address());
+			case WRITE -> fuse_operations.write$set(segment, fuse_operations.write.allocate(this::write, fuseScope).address());
 		}
 	}
 
@@ -108,140 +107,140 @@ final class FuseImpl extends Fuse {
 			var connInfo = new FuseConnInfoImpl(conn, scope);
 			connInfo.setWant(connInfo.want() | FuseConnInfo.FUSE_CAP_READDIRPLUS);
 			var config = new FuseConfigImpl(cfg, scope);
-			delegate.init(connInfo, config);
+			fuseOperations.init(connInfo, config);
 		}
 		return MemoryAddress.NULL;
 	}
 
 	private int access(MemoryAddress path, int mask) {
-		return delegate.access(path.getUtf8String(0), mask);
+		return fuseOperations.access(path.getUtf8String(0), mask);
 	}
 
 	private int chmod(MemoryAddress path, int mode, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.chmod(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
+			return fuseOperations.chmod(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	@VisibleForTesting
 	int chown(MemoryAddress path, int uid, int gid, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.chown(path.getUtf8String(0), uid, gid, new FileInfoImpl(fi, scope));
+			return fuseOperations.chown(path.getUtf8String(0), uid, gid, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int create(MemoryAddress path, int mode, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.create(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
+			return fuseOperations.create(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private void destroy(MemoryAddress addr) {
-		delegate.destroy();
+		fuseOperations.destroy();
 	}
 
 	@VisibleForTesting
 	int flush(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.flush(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return fuseOperations.flush(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	@VisibleForTesting
 	int fsync(MemoryAddress path, int datasync, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.fsync(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
+			return fuseOperations.fsync(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	@VisibleForTesting
 	int fsyncdir(MemoryAddress path, int datasync, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.fsyncdir(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
+			return fuseOperations.fsyncdir(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int getattr(MemoryAddress path, MemoryAddress stat, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
+			return this.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int mkdir(MemoryAddress path, int mode) {
-		return delegate.mkdir(path.getUtf8String(0), mode);
+		return fuseOperations.mkdir(path.getUtf8String(0), mode);
 	}
 
 	private int open(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.open(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return fuseOperations.open(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int opendir(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.opendir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return fuseOperations.opendir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int read(MemoryAddress path, MemoryAddress buf, long size, long offset, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
 			var buffer = MemorySegment.ofAddress(buf, size, scope).asByteBuffer();
-			return delegate.read(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
+			return fuseOperations.read(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int readdir(MemoryAddress path, MemoryAddress buf, MemoryAddress filler, long offset, MemoryAddress fi, int flags) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.readdir(path.getUtf8String(0), new DirFillerImpl(buf, filler, scope), offset, new FileInfoImpl(fi, scope), flags);
+			return fuseOperations.readdir(path.getUtf8String(0), new DirFillerImpl(buf, filler, scope), offset, new FileInfoImpl(fi, scope), flags);
 		}
 	}
 
 	private int readlink(MemoryAddress path, MemoryAddress buf, long len) {
 		try (var scope = MemorySession.openConfined()) {
 			var buffer = MemorySegment.ofAddress(buf, len, scope).asByteBuffer();
-			return delegate.readlink(path.getUtf8String(0), buffer, len);
+			return fuseOperations.readlink(path.getUtf8String(0), buffer, len);
 		}
 	}
 
 	private int release(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.release(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return fuseOperations.release(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int releasedir(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.releasedir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return fuseOperations.releasedir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int rename(MemoryAddress oldpath, MemoryAddress newpath, int flags) {
-		return delegate.rename(oldpath.getUtf8String(0), newpath.getUtf8String(0), flags);
+		return fuseOperations.rename(oldpath.getUtf8String(0), newpath.getUtf8String(0), flags);
 	}
 
 	private int rmdir(MemoryAddress path) {
-		return delegate.rmdir(path.getUtf8String(0));
+		return fuseOperations.rmdir(path.getUtf8String(0));
 	}
 
 	private int statfs(MemoryAddress path, MemoryAddress statvfs) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.statfs(path.getUtf8String(0), new StatvfsImpl(statvfs, scope));
+			return fuseOperations.statfs(path.getUtf8String(0), new StatvfsImpl(statvfs, scope));
 		}
 	}
 
 	private int symlink(MemoryAddress linkname, MemoryAddress target) {
-		return delegate.symlink(linkname.getUtf8String(0), target.getUtf8String(0));
+		return fuseOperations.symlink(linkname.getUtf8String(0), target.getUtf8String(0));
 	}
 
 	private int truncate(MemoryAddress path, long size, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.truncate(path.getUtf8String(0), size, new FileInfoImpl(fi, scope));
+			return fuseOperations.truncate(path.getUtf8String(0), size, new FileInfoImpl(fi, scope));
 		}
 	}
 
 
 	private int unlink(MemoryAddress path) {
-		return delegate.unlink(path.getUtf8String(0));
+		return fuseOperations.unlink(path.getUtf8String(0));
 	}
 
 	@VisibleForTesting
@@ -253,13 +252,13 @@ final class FuseImpl extends Fuse {
 				timespec.tv_sec$set(segment, 0);
 				timespec.tv_nsec$set(segment, stat_h.UTIME_NOW());
 				var time = new TimeSpecImpl(segment);
-				return delegate.utimens(path.getUtf8String(0), time, time, new FileInfoImpl(fi, scope));
+				return fuseOperations.utimens(path.getUtf8String(0), time, time, new FileInfoImpl(fi, scope));
 			} else {
 				var seq = MemoryLayout.sequenceLayout(2, timespec.$LAYOUT());
 				var segment = MemorySegment.ofAddress(times, seq.byteSize(), scope);
 				var time0 = segment.asSlice(0, timespec.$LAYOUT().byteSize());
 				var time1 = segment.asSlice(timespec.$LAYOUT().byteSize(), timespec.$LAYOUT().byteSize());
-				return delegate.utimens(path.getUtf8String(0), new TimeSpecImpl(time0), new TimeSpecImpl(time1), new FileInfoImpl(fi, scope));
+				return fuseOperations.utimens(path.getUtf8String(0), new TimeSpecImpl(time0), new TimeSpecImpl(time1), new FileInfoImpl(fi, scope));
 			}
 		}
 	}
@@ -267,7 +266,7 @@ final class FuseImpl extends Fuse {
 	private int write(MemoryAddress path, MemoryAddress buf, long size, long offset, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
 			var buffer = MemorySegment.ofAddress(buf, size, scope).asByteBuffer();
-			return delegate.write(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
+			return fuseOperations.write(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
 		}
 	}
 

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/FuseImpl.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/FuseImpl.java
@@ -30,7 +30,7 @@ final class FuseImpl extends Fuse {
 	@Override
 	protected FuseMount mount(List<String> args) throws MountFailedException {
 		var fuseArgs = parseArgs(args);
-		var fuse = fuse_h.fuse_new(fuseArgs.args(), segment, segment.byteSize(), MemoryAddress.NULL);
+		var fuse = fuse_h.fuse_new(fuseArgs.args(), fuseOperationsStruct, fuseOperationsStruct.byteSize(), MemoryAddress.NULL);
 		if (MemoryAddress.NULL.equals(fuse)) {
 			throw new MountFailedException("fuse_new failed");
 		}
@@ -69,32 +69,32 @@ final class FuseImpl extends Fuse {
 	@Override
 	protected void bind(FuseOperations.Operation operation) {
 		switch (operation) {
-			case INIT -> fuse_operations.init$set(segment, fuse_operations.init.allocate(this::init, fuseScope).address());
-			case ACCESS -> fuse_operations.access$set(segment, fuse_operations.access.allocate(this::access, fuseScope).address());
-			case CHMOD -> fuse_operations.chmod$set(segment, fuse_operations.chmod.allocate(this::chmod, fuseScope).address());
-			case CHOWN -> fuse_operations.chown$set(segment, fuse_operations.chown.allocate(this::chown, fuseScope).address());
-			case CREATE -> fuse_operations.create$set(segment, fuse_operations.create.allocate(this::create, fuseScope).address());
-			case DESTROY -> fuse_operations.destroy$set(segment, fuse_operations.destroy.allocate(this::destroy, fuseScope).address());
-			case FLUSH -> fuse_operations.flush$set(segment, fuse_operations.flush.allocate(this::flush, fuseScope).address());
-			case FSYNC -> fuse_operations.fsync$set(segment, fuse_operations.fsync.allocate(this::fsync, fuseScope).address());
-			case FSYNCDIR -> fuse_operations.fsyncdir$set(segment, fuse_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
-			case GET_ATTR -> fuse_operations.getattr$set(segment, fuse_operations.getattr.allocate(this::getattr, fuseScope).address());
-			case MKDIR -> fuse_operations.mkdir$set(segment, fuse_operations.mkdir.allocate(this::mkdir, fuseScope).address());
-			case OPEN -> fuse_operations.open$set(segment, fuse_operations.open.allocate(this::open, fuseScope).address());
-			case OPEN_DIR -> fuse_operations.opendir$set(segment, fuse_operations.opendir.allocate(this::opendir, fuseScope).address());
-			case READ -> fuse_operations.read$set(segment, fuse_operations.read.allocate(this::read, fuseScope).address());
-			case READ_DIR -> fuse_operations.readdir$set(segment, fuse_operations.readdir.allocate(this::readdir, fuseScope).address());
-			case READLINK -> fuse_operations.readlink$set(segment, fuse_operations.readlink.allocate(this::readlink, fuseScope).address());
-			case RELEASE -> fuse_operations.release$set(segment, fuse_operations.release.allocate(this::release, fuseScope).address());
-			case RELEASE_DIR -> fuse_operations.releasedir$set(segment, fuse_operations.releasedir.allocate(this::releasedir, fuseScope).address());
-			case RENAME -> fuse_operations.rename$set(segment, fuse_operations.rename.allocate(this::rename, fuseScope).address());
-			case RMDIR -> fuse_operations.rmdir$set(segment, fuse_operations.rmdir.allocate(this::rmdir, fuseScope).address());
-			case STATFS -> fuse_operations.statfs$set(segment, fuse_operations.statfs.allocate(this::statfs, fuseScope).address());
-			case SYMLINK -> fuse_operations.symlink$set(segment, fuse_operations.symlink.allocate(this::symlink, fuseScope).address());
-			case TRUNCATE -> fuse_operations.truncate$set(segment, fuse_operations.truncate.allocate(this::truncate, fuseScope).address());
-			case UNLINK -> fuse_operations.unlink$set(segment, fuse_operations.unlink.allocate(this::unlink, fuseScope).address());
-			case UTIMENS -> fuse_operations.utimens$set(segment, fuse_operations.utimens.allocate(this::utimens, fuseScope).address());
-			case WRITE -> fuse_operations.write$set(segment, fuse_operations.write.allocate(this::write, fuseScope).address());
+			case INIT -> fuse_operations.init$set(fuseOperationsStruct, fuse_operations.init.allocate(this::init, fuseScope).address());
+			case ACCESS -> fuse_operations.access$set(fuseOperationsStruct, fuse_operations.access.allocate(this::access, fuseScope).address());
+			case CHMOD -> fuse_operations.chmod$set(fuseOperationsStruct, fuse_operations.chmod.allocate(this::chmod, fuseScope).address());
+			case CHOWN -> fuse_operations.chown$set(fuseOperationsStruct, fuse_operations.chown.allocate(this::chown, fuseScope).address());
+			case CREATE -> fuse_operations.create$set(fuseOperationsStruct, fuse_operations.create.allocate(this::create, fuseScope).address());
+			case DESTROY -> fuse_operations.destroy$set(fuseOperationsStruct, fuse_operations.destroy.allocate(this::destroy, fuseScope).address());
+			case FLUSH -> fuse_operations.flush$set(fuseOperationsStruct, fuse_operations.flush.allocate(this::flush, fuseScope).address());
+			case FSYNC -> fuse_operations.fsync$set(fuseOperationsStruct, fuse_operations.fsync.allocate(this::fsync, fuseScope).address());
+			case FSYNCDIR -> fuse_operations.fsyncdir$set(fuseOperationsStruct, fuse_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
+			case GET_ATTR -> fuse_operations.getattr$set(fuseOperationsStruct, fuse_operations.getattr.allocate(this::getattr, fuseScope).address());
+			case MKDIR -> fuse_operations.mkdir$set(fuseOperationsStruct, fuse_operations.mkdir.allocate(this::mkdir, fuseScope).address());
+			case OPEN -> fuse_operations.open$set(fuseOperationsStruct, fuse_operations.open.allocate(this::open, fuseScope).address());
+			case OPEN_DIR -> fuse_operations.opendir$set(fuseOperationsStruct, fuse_operations.opendir.allocate(this::opendir, fuseScope).address());
+			case READ -> fuse_operations.read$set(fuseOperationsStruct, fuse_operations.read.allocate(this::read, fuseScope).address());
+			case READ_DIR -> fuse_operations.readdir$set(fuseOperationsStruct, fuse_operations.readdir.allocate(this::readdir, fuseScope).address());
+			case READLINK -> fuse_operations.readlink$set(fuseOperationsStruct, fuse_operations.readlink.allocate(this::readlink, fuseScope).address());
+			case RELEASE -> fuse_operations.release$set(fuseOperationsStruct, fuse_operations.release.allocate(this::release, fuseScope).address());
+			case RELEASE_DIR -> fuse_operations.releasedir$set(fuseOperationsStruct, fuse_operations.releasedir.allocate(this::releasedir, fuseScope).address());
+			case RENAME -> fuse_operations.rename$set(fuseOperationsStruct, fuse_operations.rename.allocate(this::rename, fuseScope).address());
+			case RMDIR -> fuse_operations.rmdir$set(fuseOperationsStruct, fuse_operations.rmdir.allocate(this::rmdir, fuseScope).address());
+			case STATFS -> fuse_operations.statfs$set(fuseOperationsStruct, fuse_operations.statfs.allocate(this::statfs, fuseScope).address());
+			case SYMLINK -> fuse_operations.symlink$set(fuseOperationsStruct, fuse_operations.symlink.allocate(this::symlink, fuseScope).address());
+			case TRUNCATE -> fuse_operations.truncate$set(fuseOperationsStruct, fuse_operations.truncate.allocate(this::truncate, fuseScope).address());
+			case UNLINK -> fuse_operations.unlink$set(fuseOperationsStruct, fuse_operations.unlink.allocate(this::unlink, fuseScope).address());
+			case UTIMENS -> fuse_operations.utimens$set(fuseOperationsStruct, fuse_operations.utimens.allocate(this::utimens, fuseScope).address());
+			case WRITE -> fuse_operations.write$set(fuseOperationsStruct, fuse_operations.write.allocate(this::write, fuseScope).address());
 		}
 	}
 

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/FuseImpl.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/FuseImpl.java
@@ -25,7 +25,6 @@ final class FuseImpl extends Fuse {
 
 	public FuseImpl(FuseOperations fuseOperations) {
 		super(fuseOperations, fuse_operations::allocate);
-		fuseOperations.supportedOperations().forEach(this::bind);
 	}
 
 	@Override
@@ -67,7 +66,8 @@ final class FuseImpl extends Fuse {
 		return new FuseArgs(args, opts);
 	}
 
-	private void bind(FuseOperations.Operation operation) {
+	@Override
+	protected void bind(FuseOperations.Operation operation) {
 		switch (operation) {
 			case INIT -> fuse_operations.init$set(segment, fuse_operations.init.allocate(this::init, fuseScope).address());
 			case ACCESS -> fuse_operations.access$set(segment, fuse_operations.access.allocate(this::access, fuseScope).address());

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/FuseImpl.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/FuseImpl.java
@@ -23,11 +23,8 @@ import java.util.List;
 
 final class FuseImpl extends Fuse {
 
-	private final MemorySegment segment;
-
 	public FuseImpl(FuseOperations fuseOperations) {
-		super(fuseOperations);
-		this.segment = fuse_operations.allocate(fuseScope);
+		super(fuseOperations, fuse_operations::allocate);
 		fuseOperations.supportedOperations().forEach(this::bind);
 	}
 

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/FuseImpl.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/FuseImpl.java
@@ -159,7 +159,7 @@ final class FuseImpl extends Fuse {
 
 	private int getattr(MemoryAddress path, MemoryAddress stat, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return this.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
+			return fuseOperations.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
 		}
 	}
 

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/FuseImpl.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/FuseImpl.java
@@ -6,9 +6,9 @@ import org.cryptomator.jfuse.api.FuseMount;
 import org.cryptomator.jfuse.api.FuseOperations;
 import org.cryptomator.jfuse.api.MountFailedException;
 import org.cryptomator.jfuse.linux.amd64.extr.fuse_args;
+import org.cryptomator.jfuse.linux.amd64.extr.fuse_cmdline_opts;
 import org.cryptomator.jfuse.linux.amd64.extr.fuse_h;
 import org.cryptomator.jfuse.linux.amd64.extr.fuse_operations;
-import org.cryptomator.jfuse.linux.amd64.extr.fuse_cmdline_opts;
 import org.cryptomator.jfuse.linux.amd64.extr.stat_h;
 import org.cryptomator.jfuse.linux.amd64.extr.timespec;
 import org.jetbrains.annotations.VisibleForTesting;
@@ -23,19 +23,18 @@ import java.util.List;
 
 final class FuseImpl extends Fuse {
 
-	private final FuseOperations delegate;
-	private final MemorySegment fuseOps;
+	private final MemorySegment segment;
 
 	public FuseImpl(FuseOperations fuseOperations) {
-		this.fuseOps = fuse_operations.allocate(fuseScope);
-		this.delegate = fuseOperations;
+		super(fuseOperations);
+		this.segment = fuse_operations.allocate(fuseScope);
 		fuseOperations.supportedOperations().forEach(this::bind);
 	}
 
 	@Override
 	protected FuseMount mount(List<String> args) throws MountFailedException {
 		var fuseArgs = parseArgs(args);
-		var fuse = fuse_h.fuse_new(fuseArgs.args(), fuseOps, fuseOps.byteSize(), MemoryAddress.NULL);
+		var fuse = fuse_h.fuse_new(fuseArgs.args(), segment, segment.byteSize(), MemoryAddress.NULL);
 		if (MemoryAddress.NULL.equals(fuse)) {
 			throw new MountFailedException("fuse_new failed");
 		}
@@ -73,32 +72,32 @@ final class FuseImpl extends Fuse {
 
 	private void bind(FuseOperations.Operation operation) {
 		switch (operation) {
-			case INIT -> fuse_operations.init$set(fuseOps, fuse_operations.init.allocate(this::init, fuseScope).address());
-			case ACCESS -> fuse_operations.access$set(fuseOps, fuse_operations.access.allocate(this::access, fuseScope).address());
-			case CHMOD -> fuse_operations.chmod$set(fuseOps, fuse_operations.chmod.allocate(this::chmod, fuseScope).address());
-			case CHOWN -> fuse_operations.chown$set(fuseOps, fuse_operations.chown.allocate(this::chown, fuseScope).address());
-			case CREATE -> fuse_operations.create$set(fuseOps, fuse_operations.create.allocate(this::create, fuseScope).address());
-			case DESTROY -> fuse_operations.destroy$set(fuseOps, fuse_operations.destroy.allocate(this::destroy, fuseScope).address());
-			case FLUSH -> fuse_operations.flush$set(fuseOps, fuse_operations.flush.allocate(this::flush, fuseScope).address());
-			case FSYNC -> fuse_operations.fsync$set(fuseOps, fuse_operations.fsync.allocate(this::fsync, fuseScope).address());
-			case FSYNCDIR -> fuse_operations.fsyncdir$set(fuseOps, fuse_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
-			case GET_ATTR -> fuse_operations.getattr$set(fuseOps, fuse_operations.getattr.allocate(this::getattr, fuseScope).address());
-			case MKDIR -> fuse_operations.mkdir$set(fuseOps, fuse_operations.mkdir.allocate(this::mkdir, fuseScope).address());
-			case OPEN -> fuse_operations.open$set(fuseOps, fuse_operations.open.allocate(this::open, fuseScope).address());
-			case OPEN_DIR -> fuse_operations.opendir$set(fuseOps, fuse_operations.opendir.allocate(this::opendir, fuseScope).address());
-			case READ -> fuse_operations.read$set(fuseOps, fuse_operations.read.allocate(this::read, fuseScope).address());
-			case READ_DIR -> fuse_operations.readdir$set(fuseOps, fuse_operations.readdir.allocate(this::readdir, fuseScope).address());
-			case READLINK -> fuse_operations.readlink$set(fuseOps, fuse_operations.readlink.allocate(this::readlink, fuseScope).address());
-			case RELEASE -> fuse_operations.release$set(fuseOps, fuse_operations.release.allocate(this::release, fuseScope).address());
-			case RELEASE_DIR -> fuse_operations.releasedir$set(fuseOps, fuse_operations.releasedir.allocate(this::releasedir, fuseScope).address());
-			case RENAME -> fuse_operations.rename$set(fuseOps, fuse_operations.rename.allocate(this::rename, fuseScope).address());
-			case RMDIR -> fuse_operations.rmdir$set(fuseOps, fuse_operations.rmdir.allocate(this::rmdir, fuseScope).address());
-			case STATFS -> fuse_operations.statfs$set(fuseOps, fuse_operations.statfs.allocate(this::statfs, fuseScope).address());
-			case SYMLINK -> fuse_operations.symlink$set(fuseOps, fuse_operations.symlink.allocate(this::symlink, fuseScope).address());
-			case TRUNCATE -> fuse_operations.truncate$set(fuseOps, fuse_operations.truncate.allocate(this::truncate, fuseScope).address());
-			case UNLINK -> fuse_operations.unlink$set(fuseOps, fuse_operations.unlink.allocate(this::unlink, fuseScope).address());
-			case UTIMENS -> fuse_operations.utimens$set(fuseOps, fuse_operations.utimens.allocate(this::utimens, fuseScope).address());
-			case WRITE -> fuse_operations.write$set(fuseOps, fuse_operations.write.allocate(this::write, fuseScope).address());
+			case INIT -> fuse_operations.init$set(segment, fuse_operations.init.allocate(this::init, fuseScope).address());
+			case ACCESS -> fuse_operations.access$set(segment, fuse_operations.access.allocate(this::access, fuseScope).address());
+			case CHMOD -> fuse_operations.chmod$set(segment, fuse_operations.chmod.allocate(this::chmod, fuseScope).address());
+			case CHOWN -> fuse_operations.chown$set(segment, fuse_operations.chown.allocate(this::chown, fuseScope).address());
+			case CREATE -> fuse_operations.create$set(segment, fuse_operations.create.allocate(this::create, fuseScope).address());
+			case DESTROY -> fuse_operations.destroy$set(segment, fuse_operations.destroy.allocate(this::destroy, fuseScope).address());
+			case FLUSH -> fuse_operations.flush$set(segment, fuse_operations.flush.allocate(this::flush, fuseScope).address());
+			case FSYNC -> fuse_operations.fsync$set(segment, fuse_operations.fsync.allocate(this::fsync, fuseScope).address());
+			case FSYNCDIR -> fuse_operations.fsyncdir$set(segment, fuse_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
+			case GET_ATTR -> fuse_operations.getattr$set(segment, fuse_operations.getattr.allocate(this::getattr, fuseScope).address());
+			case MKDIR -> fuse_operations.mkdir$set(segment, fuse_operations.mkdir.allocate(this::mkdir, fuseScope).address());
+			case OPEN -> fuse_operations.open$set(segment, fuse_operations.open.allocate(this::open, fuseScope).address());
+			case OPEN_DIR -> fuse_operations.opendir$set(segment, fuse_operations.opendir.allocate(this::opendir, fuseScope).address());
+			case READ -> fuse_operations.read$set(segment, fuse_operations.read.allocate(this::read, fuseScope).address());
+			case READ_DIR -> fuse_operations.readdir$set(segment, fuse_operations.readdir.allocate(this::readdir, fuseScope).address());
+			case READLINK -> fuse_operations.readlink$set(segment, fuse_operations.readlink.allocate(this::readlink, fuseScope).address());
+			case RELEASE -> fuse_operations.release$set(segment, fuse_operations.release.allocate(this::release, fuseScope).address());
+			case RELEASE_DIR -> fuse_operations.releasedir$set(segment, fuse_operations.releasedir.allocate(this::releasedir, fuseScope).address());
+			case RENAME -> fuse_operations.rename$set(segment, fuse_operations.rename.allocate(this::rename, fuseScope).address());
+			case RMDIR -> fuse_operations.rmdir$set(segment, fuse_operations.rmdir.allocate(this::rmdir, fuseScope).address());
+			case STATFS -> fuse_operations.statfs$set(segment, fuse_operations.statfs.allocate(this::statfs, fuseScope).address());
+			case SYMLINK -> fuse_operations.symlink$set(segment, fuse_operations.symlink.allocate(this::symlink, fuseScope).address());
+			case TRUNCATE -> fuse_operations.truncate$set(segment, fuse_operations.truncate.allocate(this::truncate, fuseScope).address());
+			case UNLINK -> fuse_operations.unlink$set(segment, fuse_operations.unlink.allocate(this::unlink, fuseScope).address());
+			case UTIMENS -> fuse_operations.utimens$set(segment, fuse_operations.utimens.allocate(this::utimens, fuseScope).address());
+			case WRITE -> fuse_operations.write$set(segment, fuse_operations.write.allocate(this::write, fuseScope).address());
 		}
 	}
 
@@ -108,139 +107,139 @@ final class FuseImpl extends Fuse {
 			var connInfo = new FuseConnInfoImpl(conn, scope);
 			connInfo.setWant(connInfo.want() | FuseConnInfo.FUSE_CAP_READDIRPLUS);
 			var config = new FuseConfigImpl(cfg, scope);
-			delegate.init(connInfo, config);
+			fuseOperations.init(connInfo, config);
 		}
 		return MemoryAddress.NULL;
 	}
 
 	private int access(MemoryAddress path, int mask) {
-		return delegate.access(path.getUtf8String(0), mask);
+		return fuseOperations.access(path.getUtf8String(0), mask);
 	}
 
 	private int chmod(MemoryAddress path, int mode, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.chmod(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
+			return fuseOperations.chmod(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	@VisibleForTesting
 	int chown(MemoryAddress path, int uid, int gid, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.chown(path.getUtf8String(0), uid, gid, new FileInfoImpl(fi, scope));
+			return fuseOperations.chown(path.getUtf8String(0), uid, gid, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int create(MemoryAddress path, int mode, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.create(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
+			return fuseOperations.create(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private void destroy(MemoryAddress addr) {
-		delegate.destroy();
+		fuseOperations.destroy();
 	}
 
 	@VisibleForTesting
 	int flush(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.flush(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return fuseOperations.flush(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	@VisibleForTesting
 	int fsync(MemoryAddress path, int datasync, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.fsync(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
+			return fuseOperations.fsync(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	@VisibleForTesting
 	int fsyncdir(MemoryAddress path, int datasync, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.fsyncdir(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
+			return fuseOperations.fsyncdir(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int getattr(MemoryAddress path, MemoryAddress stat, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
+			return this.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int mkdir(MemoryAddress path, int mode) {
-		return delegate.mkdir(path.getUtf8String(0), mode);
+		return fuseOperations.mkdir(path.getUtf8String(0), mode);
 	}
 
 	private int open(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.open(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return fuseOperations.open(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int opendir(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.opendir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return fuseOperations.opendir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int read(MemoryAddress path, MemoryAddress buf, long size, long offset, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
 			var buffer = MemorySegment.ofAddress(buf, size, scope).asByteBuffer();
-			return delegate.read(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
+			return fuseOperations.read(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int readdir(MemoryAddress path, MemoryAddress buf, MemoryAddress filler, long offset, MemoryAddress fi, int flags) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.readdir(path.getUtf8String(0), new DirFillerImpl(buf, filler, scope), offset, new FileInfoImpl(fi, scope), flags);
+			return fuseOperations.readdir(path.getUtf8String(0), new DirFillerImpl(buf, filler, scope), offset, new FileInfoImpl(fi, scope), flags);
 		}
 	}
 
 	private int readlink(MemoryAddress path, MemoryAddress buf, long len) {
 		try (var scope = MemorySession.openConfined()) {
 			var buffer = MemorySegment.ofAddress(buf, len, scope).asByteBuffer();
-			return delegate.readlink(path.getUtf8String(0), buffer, len);
+			return fuseOperations.readlink(path.getUtf8String(0), buffer, len);
 		}
 	}
 
 	private int release(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.release(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return fuseOperations.release(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int releasedir(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.releasedir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return fuseOperations.releasedir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int rename(MemoryAddress oldpath, MemoryAddress newpath, int flags) {
-		return delegate.rename(oldpath.getUtf8String(0), newpath.getUtf8String(0), flags);
+		return fuseOperations.rename(oldpath.getUtf8String(0), newpath.getUtf8String(0), flags);
 	}
 
 	private int rmdir(MemoryAddress path) {
-		return delegate.rmdir(path.getUtf8String(0));
+		return fuseOperations.rmdir(path.getUtf8String(0));
 	}
 
 	private int statfs(MemoryAddress path, MemoryAddress statvfs) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.statfs(path.getUtf8String(0), new StatvfsImpl(statvfs, scope));
+			return fuseOperations.statfs(path.getUtf8String(0), new StatvfsImpl(statvfs, scope));
 		}
 	}
 
 	private int symlink(MemoryAddress linkname, MemoryAddress target) {
-		return delegate.symlink(linkname.getUtf8String(0), target.getUtf8String(0));
+		return fuseOperations.symlink(linkname.getUtf8String(0), target.getUtf8String(0));
 	}
 
 	private int truncate(MemoryAddress path, long size, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.truncate(path.getUtf8String(0), size, new FileInfoImpl(fi, scope));
+			return fuseOperations.truncate(path.getUtf8String(0), size, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int unlink(MemoryAddress path) {
-		return delegate.unlink(path.getUtf8String(0));
+		return fuseOperations.unlink(path.getUtf8String(0));
 	}
 
 	@VisibleForTesting
@@ -252,13 +251,13 @@ final class FuseImpl extends Fuse {
 				timespec.tv_sec$set(segment, 0);
 				timespec.tv_nsec$set(segment, stat_h.UTIME_NOW());
 				var time = new TimeSpecImpl(segment);
-				return delegate.utimens(path.getUtf8String(0), time, time, new FileInfoImpl(fi, scope));
+				return fuseOperations.utimens(path.getUtf8String(0), time, time, new FileInfoImpl(fi, scope));
 			} else {
 				var seq = MemoryLayout.sequenceLayout(2, timespec.$LAYOUT());
 				var segment = MemorySegment.ofAddress(times, seq.byteSize(), scope);
 				var time0 = segment.asSlice(0, timespec.$LAYOUT().byteSize());
 				var time1 = segment.asSlice(timespec.$LAYOUT().byteSize(), timespec.$LAYOUT().byteSize());
-				return delegate.utimens(path.getUtf8String(0), new TimeSpecImpl(time0), new TimeSpecImpl(time1), new FileInfoImpl(fi, scope));
+				return fuseOperations.utimens(path.getUtf8String(0), new TimeSpecImpl(time0), new TimeSpecImpl(time1), new FileInfoImpl(fi, scope));
 			}
 		}
 	}
@@ -266,7 +265,7 @@ final class FuseImpl extends Fuse {
 	private int write(MemoryAddress path, MemoryAddress buf, long size, long offset, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
 			var buffer = MemorySegment.ofAddress(buf, size, scope).asByteBuffer();
-			return delegate.write(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
+			return fuseOperations.write(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
 		}
 	}
 

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/FuseImpl.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/FuseImpl.java
@@ -30,7 +30,7 @@ final class FuseImpl extends Fuse {
 	@Override
 	protected FuseMount mount(List<String> args) throws MountFailedException {
 		var fuseArgs = parseArgs(args);
-		var fuse = fuse_h.fuse_new(fuseArgs.args(), fuseOperationsStruct, fuseOperationsStruct.byteSize(), MemoryAddress.NULL);
+		var fuse = fuse_h.fuse_new(fuseArgs.args(), fuseOps, fuseOps.byteSize(), MemoryAddress.NULL);
 		if (MemoryAddress.NULL.equals(fuse)) {
 			throw new MountFailedException("fuse_new failed");
 		}
@@ -69,32 +69,32 @@ final class FuseImpl extends Fuse {
 	@Override
 	protected void bind(FuseOperations.Operation operation) {
 		switch (operation) {
-			case INIT -> fuse_operations.init$set(fuseOperationsStruct, fuse_operations.init.allocate(this::init, fuseScope).address());
-			case ACCESS -> fuse_operations.access$set(fuseOperationsStruct, fuse_operations.access.allocate(this::access, fuseScope).address());
-			case CHMOD -> fuse_operations.chmod$set(fuseOperationsStruct, fuse_operations.chmod.allocate(this::chmod, fuseScope).address());
-			case CHOWN -> fuse_operations.chown$set(fuseOperationsStruct, fuse_operations.chown.allocate(this::chown, fuseScope).address());
-			case CREATE -> fuse_operations.create$set(fuseOperationsStruct, fuse_operations.create.allocate(this::create, fuseScope).address());
-			case DESTROY -> fuse_operations.destroy$set(fuseOperationsStruct, fuse_operations.destroy.allocate(this::destroy, fuseScope).address());
-			case FLUSH -> fuse_operations.flush$set(fuseOperationsStruct, fuse_operations.flush.allocate(this::flush, fuseScope).address());
-			case FSYNC -> fuse_operations.fsync$set(fuseOperationsStruct, fuse_operations.fsync.allocate(this::fsync, fuseScope).address());
-			case FSYNCDIR -> fuse_operations.fsyncdir$set(fuseOperationsStruct, fuse_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
-			case GET_ATTR -> fuse_operations.getattr$set(fuseOperationsStruct, fuse_operations.getattr.allocate(this::getattr, fuseScope).address());
-			case MKDIR -> fuse_operations.mkdir$set(fuseOperationsStruct, fuse_operations.mkdir.allocate(this::mkdir, fuseScope).address());
-			case OPEN -> fuse_operations.open$set(fuseOperationsStruct, fuse_operations.open.allocate(this::open, fuseScope).address());
-			case OPEN_DIR -> fuse_operations.opendir$set(fuseOperationsStruct, fuse_operations.opendir.allocate(this::opendir, fuseScope).address());
-			case READ -> fuse_operations.read$set(fuseOperationsStruct, fuse_operations.read.allocate(this::read, fuseScope).address());
-			case READ_DIR -> fuse_operations.readdir$set(fuseOperationsStruct, fuse_operations.readdir.allocate(this::readdir, fuseScope).address());
-			case READLINK -> fuse_operations.readlink$set(fuseOperationsStruct, fuse_operations.readlink.allocate(this::readlink, fuseScope).address());
-			case RELEASE -> fuse_operations.release$set(fuseOperationsStruct, fuse_operations.release.allocate(this::release, fuseScope).address());
-			case RELEASE_DIR -> fuse_operations.releasedir$set(fuseOperationsStruct, fuse_operations.releasedir.allocate(this::releasedir, fuseScope).address());
-			case RENAME -> fuse_operations.rename$set(fuseOperationsStruct, fuse_operations.rename.allocate(this::rename, fuseScope).address());
-			case RMDIR -> fuse_operations.rmdir$set(fuseOperationsStruct, fuse_operations.rmdir.allocate(this::rmdir, fuseScope).address());
-			case STATFS -> fuse_operations.statfs$set(fuseOperationsStruct, fuse_operations.statfs.allocate(this::statfs, fuseScope).address());
-			case SYMLINK -> fuse_operations.symlink$set(fuseOperationsStruct, fuse_operations.symlink.allocate(this::symlink, fuseScope).address());
-			case TRUNCATE -> fuse_operations.truncate$set(fuseOperationsStruct, fuse_operations.truncate.allocate(this::truncate, fuseScope).address());
-			case UNLINK -> fuse_operations.unlink$set(fuseOperationsStruct, fuse_operations.unlink.allocate(this::unlink, fuseScope).address());
-			case UTIMENS -> fuse_operations.utimens$set(fuseOperationsStruct, fuse_operations.utimens.allocate(this::utimens, fuseScope).address());
-			case WRITE -> fuse_operations.write$set(fuseOperationsStruct, fuse_operations.write.allocate(this::write, fuseScope).address());
+			case INIT -> fuse_operations.init$set(fuseOps, fuse_operations.init.allocate(this::init, fuseScope).address());
+			case ACCESS -> fuse_operations.access$set(fuseOps, fuse_operations.access.allocate(this::access, fuseScope).address());
+			case CHMOD -> fuse_operations.chmod$set(fuseOps, fuse_operations.chmod.allocate(this::chmod, fuseScope).address());
+			case CHOWN -> fuse_operations.chown$set(fuseOps, fuse_operations.chown.allocate(this::chown, fuseScope).address());
+			case CREATE -> fuse_operations.create$set(fuseOps, fuse_operations.create.allocate(this::create, fuseScope).address());
+			case DESTROY -> fuse_operations.destroy$set(fuseOps, fuse_operations.destroy.allocate(this::destroy, fuseScope).address());
+			case FLUSH -> fuse_operations.flush$set(fuseOps, fuse_operations.flush.allocate(this::flush, fuseScope).address());
+			case FSYNC -> fuse_operations.fsync$set(fuseOps, fuse_operations.fsync.allocate(this::fsync, fuseScope).address());
+			case FSYNCDIR -> fuse_operations.fsyncdir$set(fuseOps, fuse_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
+			case GET_ATTR -> fuse_operations.getattr$set(fuseOps, fuse_operations.getattr.allocate(this::getattr, fuseScope).address());
+			case MKDIR -> fuse_operations.mkdir$set(fuseOps, fuse_operations.mkdir.allocate(this::mkdir, fuseScope).address());
+			case OPEN -> fuse_operations.open$set(fuseOps, fuse_operations.open.allocate(this::open, fuseScope).address());
+			case OPEN_DIR -> fuse_operations.opendir$set(fuseOps, fuse_operations.opendir.allocate(this::opendir, fuseScope).address());
+			case READ -> fuse_operations.read$set(fuseOps, fuse_operations.read.allocate(this::read, fuseScope).address());
+			case READ_DIR -> fuse_operations.readdir$set(fuseOps, fuse_operations.readdir.allocate(this::readdir, fuseScope).address());
+			case READLINK -> fuse_operations.readlink$set(fuseOps, fuse_operations.readlink.allocate(this::readlink, fuseScope).address());
+			case RELEASE -> fuse_operations.release$set(fuseOps, fuse_operations.release.allocate(this::release, fuseScope).address());
+			case RELEASE_DIR -> fuse_operations.releasedir$set(fuseOps, fuse_operations.releasedir.allocate(this::releasedir, fuseScope).address());
+			case RENAME -> fuse_operations.rename$set(fuseOps, fuse_operations.rename.allocate(this::rename, fuseScope).address());
+			case RMDIR -> fuse_operations.rmdir$set(fuseOps, fuse_operations.rmdir.allocate(this::rmdir, fuseScope).address());
+			case STATFS -> fuse_operations.statfs$set(fuseOps, fuse_operations.statfs.allocate(this::statfs, fuseScope).address());
+			case SYMLINK -> fuse_operations.symlink$set(fuseOps, fuse_operations.symlink.allocate(this::symlink, fuseScope).address());
+			case TRUNCATE -> fuse_operations.truncate$set(fuseOps, fuse_operations.truncate.allocate(this::truncate, fuseScope).address());
+			case UNLINK -> fuse_operations.unlink$set(fuseOps, fuse_operations.unlink.allocate(this::unlink, fuseScope).address());
+			case UTIMENS -> fuse_operations.utimens$set(fuseOps, fuse_operations.utimens.allocate(this::utimens, fuseScope).address());
+			case WRITE -> fuse_operations.write$set(fuseOps, fuse_operations.write.allocate(this::write, fuseScope).address());
 		}
 	}
 
@@ -104,139 +104,139 @@ final class FuseImpl extends Fuse {
 			var connInfo = new FuseConnInfoImpl(conn, scope);
 			connInfo.setWant(connInfo.want() | FuseConnInfo.FUSE_CAP_READDIRPLUS);
 			var config = new FuseConfigImpl(cfg, scope);
-			fuseOperations.init(connInfo, config);
+			delegate.init(connInfo, config);
 		}
 		return MemoryAddress.NULL;
 	}
 
 	private int access(MemoryAddress path, int mask) {
-		return fuseOperations.access(path.getUtf8String(0), mask);
+		return delegate.access(path.getUtf8String(0), mask);
 	}
 
 	private int chmod(MemoryAddress path, int mode, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.chmod(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
+			return delegate.chmod(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	@VisibleForTesting
 	int chown(MemoryAddress path, int uid, int gid, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.chown(path.getUtf8String(0), uid, gid, new FileInfoImpl(fi, scope));
+			return delegate.chown(path.getUtf8String(0), uid, gid, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int create(MemoryAddress path, int mode, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.create(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
+			return delegate.create(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private void destroy(MemoryAddress addr) {
-		fuseOperations.destroy();
+		delegate.destroy();
 	}
 
 	@VisibleForTesting
 	int flush(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.flush(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return delegate.flush(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	@VisibleForTesting
 	int fsync(MemoryAddress path, int datasync, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.fsync(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
+			return delegate.fsync(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	@VisibleForTesting
 	int fsyncdir(MemoryAddress path, int datasync, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.fsyncdir(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
+			return delegate.fsyncdir(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int getattr(MemoryAddress path, MemoryAddress stat, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
+			return delegate.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int mkdir(MemoryAddress path, int mode) {
-		return fuseOperations.mkdir(path.getUtf8String(0), mode);
+		return delegate.mkdir(path.getUtf8String(0), mode);
 	}
 
 	private int open(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.open(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return delegate.open(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int opendir(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.opendir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return delegate.opendir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int read(MemoryAddress path, MemoryAddress buf, long size, long offset, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
 			var buffer = MemorySegment.ofAddress(buf, size, scope).asByteBuffer();
-			return fuseOperations.read(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
+			return delegate.read(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int readdir(MemoryAddress path, MemoryAddress buf, MemoryAddress filler, long offset, MemoryAddress fi, int flags) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.readdir(path.getUtf8String(0), new DirFillerImpl(buf, filler, scope), offset, new FileInfoImpl(fi, scope), flags);
+			return delegate.readdir(path.getUtf8String(0), new DirFillerImpl(buf, filler, scope), offset, new FileInfoImpl(fi, scope), flags);
 		}
 	}
 
 	private int readlink(MemoryAddress path, MemoryAddress buf, long len) {
 		try (var scope = MemorySession.openConfined()) {
 			var buffer = MemorySegment.ofAddress(buf, len, scope).asByteBuffer();
-			return fuseOperations.readlink(path.getUtf8String(0), buffer, len);
+			return delegate.readlink(path.getUtf8String(0), buffer, len);
 		}
 	}
 
 	private int release(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.release(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return delegate.release(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int releasedir(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.releasedir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return delegate.releasedir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int rename(MemoryAddress oldpath, MemoryAddress newpath, int flags) {
-		return fuseOperations.rename(oldpath.getUtf8String(0), newpath.getUtf8String(0), flags);
+		return delegate.rename(oldpath.getUtf8String(0), newpath.getUtf8String(0), flags);
 	}
 
 	private int rmdir(MemoryAddress path) {
-		return fuseOperations.rmdir(path.getUtf8String(0));
+		return delegate.rmdir(path.getUtf8String(0));
 	}
 
 	private int statfs(MemoryAddress path, MemoryAddress statvfs) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.statfs(path.getUtf8String(0), new StatvfsImpl(statvfs, scope));
+			return delegate.statfs(path.getUtf8String(0), new StatvfsImpl(statvfs, scope));
 		}
 	}
 
 	private int symlink(MemoryAddress linkname, MemoryAddress target) {
-		return fuseOperations.symlink(linkname.getUtf8String(0), target.getUtf8String(0));
+		return delegate.symlink(linkname.getUtf8String(0), target.getUtf8String(0));
 	}
 
 	private int truncate(MemoryAddress path, long size, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.truncate(path.getUtf8String(0), size, new FileInfoImpl(fi, scope));
+			return delegate.truncate(path.getUtf8String(0), size, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int unlink(MemoryAddress path) {
-		return fuseOperations.unlink(path.getUtf8String(0));
+		return delegate.unlink(path.getUtf8String(0));
 	}
 
 	@VisibleForTesting
@@ -248,13 +248,13 @@ final class FuseImpl extends Fuse {
 				timespec.tv_sec$set(segment, 0);
 				timespec.tv_nsec$set(segment, stat_h.UTIME_NOW());
 				var time = new TimeSpecImpl(segment);
-				return fuseOperations.utimens(path.getUtf8String(0), time, time, new FileInfoImpl(fi, scope));
+				return delegate.utimens(path.getUtf8String(0), time, time, new FileInfoImpl(fi, scope));
 			} else {
 				var seq = MemoryLayout.sequenceLayout(2, timespec.$LAYOUT());
 				var segment = MemorySegment.ofAddress(times, seq.byteSize(), scope);
 				var time0 = segment.asSlice(0, timespec.$LAYOUT().byteSize());
 				var time1 = segment.asSlice(timespec.$LAYOUT().byteSize(), timespec.$LAYOUT().byteSize());
-				return fuseOperations.utimens(path.getUtf8String(0), new TimeSpecImpl(time0), new TimeSpecImpl(time1), new FileInfoImpl(fi, scope));
+				return delegate.utimens(path.getUtf8String(0), new TimeSpecImpl(time0), new TimeSpecImpl(time1), new FileInfoImpl(fi, scope));
 			}
 		}
 	}
@@ -262,7 +262,7 @@ final class FuseImpl extends Fuse {
 	private int write(MemoryAddress path, MemoryAddress buf, long size, long offset, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
 			var buffer = MemorySegment.ofAddress(buf, size, scope).asByteBuffer();
-			return fuseOperations.write(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
+			return delegate.write(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
 		}
 	}
 

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/FuseImpl.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/FuseImpl.java
@@ -30,7 +30,7 @@ final class FuseImpl extends Fuse {
 	@Override
 	protected FuseMount mount(List<String> args) throws MountFailedException {
 		var fuseArgs = parseArgs(args);
-		var fuse = fuse_h.fuse_new(fuseArgs.args(), segment, segment.byteSize(), MemoryAddress.NULL);
+		var fuse = fuse_h.fuse_new(fuseArgs.args(), fuseOperationsStruct, fuseOperationsStruct.byteSize(), MemoryAddress.NULL);
 		if (MemoryAddress.NULL.equals(fuse)) {
 			throw new MountFailedException("fuse_new failed");
 		}
@@ -69,32 +69,32 @@ final class FuseImpl extends Fuse {
 	@Override
 	protected void bind(FuseOperations.Operation operation) {
 		switch (operation) {
-			case INIT -> fuse_operations.init$set(segment, fuse_operations.init.allocate(this::init, fuseScope).address());
-			case ACCESS -> fuse_operations.access$set(segment, fuse_operations.access.allocate(this::access, fuseScope).address());
-			case CHMOD -> fuse_operations.chmod$set(segment, fuse_operations.chmod.allocate(this::chmod, fuseScope).address());
-			case CHOWN -> fuse_operations.chown$set(segment, fuse_operations.chown.allocate(this::chown, fuseScope).address());
-			case CREATE -> fuse_operations.create$set(segment, fuse_operations.create.allocate(this::create, fuseScope).address());
-			case DESTROY -> fuse_operations.destroy$set(segment, fuse_operations.destroy.allocate(this::destroy, fuseScope).address());
-			case FLUSH -> fuse_operations.flush$set(segment, fuse_operations.flush.allocate(this::flush, fuseScope).address());
-			case FSYNC -> fuse_operations.fsync$set(segment, fuse_operations.fsync.allocate(this::fsync, fuseScope).address());
-			case FSYNCDIR -> fuse_operations.fsyncdir$set(segment, fuse_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
-			case GET_ATTR -> fuse_operations.getattr$set(segment, fuse_operations.getattr.allocate(this::getattr, fuseScope).address());
-			case MKDIR -> fuse_operations.mkdir$set(segment, fuse_operations.mkdir.allocate(this::mkdir, fuseScope).address());
-			case OPEN -> fuse_operations.open$set(segment, fuse_operations.open.allocate(this::open, fuseScope).address());
-			case OPEN_DIR -> fuse_operations.opendir$set(segment, fuse_operations.opendir.allocate(this::opendir, fuseScope).address());
-			case READ -> fuse_operations.read$set(segment, fuse_operations.read.allocate(this::read, fuseScope).address());
-			case READ_DIR -> fuse_operations.readdir$set(segment, fuse_operations.readdir.allocate(this::readdir, fuseScope).address());
-			case READLINK -> fuse_operations.readlink$set(segment, fuse_operations.readlink.allocate(this::readlink, fuseScope).address());
-			case RELEASE -> fuse_operations.release$set(segment, fuse_operations.release.allocate(this::release, fuseScope).address());
-			case RELEASE_DIR -> fuse_operations.releasedir$set(segment, fuse_operations.releasedir.allocate(this::releasedir, fuseScope).address());
-			case RENAME -> fuse_operations.rename$set(segment, fuse_operations.rename.allocate(this::rename, fuseScope).address());
-			case RMDIR -> fuse_operations.rmdir$set(segment, fuse_operations.rmdir.allocate(this::rmdir, fuseScope).address());
-			case STATFS -> fuse_operations.statfs$set(segment, fuse_operations.statfs.allocate(this::statfs, fuseScope).address());
-			case SYMLINK -> fuse_operations.symlink$set(segment, fuse_operations.symlink.allocate(this::symlink, fuseScope).address());
-			case TRUNCATE -> fuse_operations.truncate$set(segment, fuse_operations.truncate.allocate(this::truncate, fuseScope).address());
-			case UNLINK -> fuse_operations.unlink$set(segment, fuse_operations.unlink.allocate(this::unlink, fuseScope).address());
-			case UTIMENS -> fuse_operations.utimens$set(segment, fuse_operations.utimens.allocate(this::utimens, fuseScope).address());
-			case WRITE -> fuse_operations.write$set(segment, fuse_operations.write.allocate(this::write, fuseScope).address());
+			case INIT -> fuse_operations.init$set(fuseOperationsStruct, fuse_operations.init.allocate(this::init, fuseScope).address());
+			case ACCESS -> fuse_operations.access$set(fuseOperationsStruct, fuse_operations.access.allocate(this::access, fuseScope).address());
+			case CHMOD -> fuse_operations.chmod$set(fuseOperationsStruct, fuse_operations.chmod.allocate(this::chmod, fuseScope).address());
+			case CHOWN -> fuse_operations.chown$set(fuseOperationsStruct, fuse_operations.chown.allocate(this::chown, fuseScope).address());
+			case CREATE -> fuse_operations.create$set(fuseOperationsStruct, fuse_operations.create.allocate(this::create, fuseScope).address());
+			case DESTROY -> fuse_operations.destroy$set(fuseOperationsStruct, fuse_operations.destroy.allocate(this::destroy, fuseScope).address());
+			case FLUSH -> fuse_operations.flush$set(fuseOperationsStruct, fuse_operations.flush.allocate(this::flush, fuseScope).address());
+			case FSYNC -> fuse_operations.fsync$set(fuseOperationsStruct, fuse_operations.fsync.allocate(this::fsync, fuseScope).address());
+			case FSYNCDIR -> fuse_operations.fsyncdir$set(fuseOperationsStruct, fuse_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
+			case GET_ATTR -> fuse_operations.getattr$set(fuseOperationsStruct, fuse_operations.getattr.allocate(this::getattr, fuseScope).address());
+			case MKDIR -> fuse_operations.mkdir$set(fuseOperationsStruct, fuse_operations.mkdir.allocate(this::mkdir, fuseScope).address());
+			case OPEN -> fuse_operations.open$set(fuseOperationsStruct, fuse_operations.open.allocate(this::open, fuseScope).address());
+			case OPEN_DIR -> fuse_operations.opendir$set(fuseOperationsStruct, fuse_operations.opendir.allocate(this::opendir, fuseScope).address());
+			case READ -> fuse_operations.read$set(fuseOperationsStruct, fuse_operations.read.allocate(this::read, fuseScope).address());
+			case READ_DIR -> fuse_operations.readdir$set(fuseOperationsStruct, fuse_operations.readdir.allocate(this::readdir, fuseScope).address());
+			case READLINK -> fuse_operations.readlink$set(fuseOperationsStruct, fuse_operations.readlink.allocate(this::readlink, fuseScope).address());
+			case RELEASE -> fuse_operations.release$set(fuseOperationsStruct, fuse_operations.release.allocate(this::release, fuseScope).address());
+			case RELEASE_DIR -> fuse_operations.releasedir$set(fuseOperationsStruct, fuse_operations.releasedir.allocate(this::releasedir, fuseScope).address());
+			case RENAME -> fuse_operations.rename$set(fuseOperationsStruct, fuse_operations.rename.allocate(this::rename, fuseScope).address());
+			case RMDIR -> fuse_operations.rmdir$set(fuseOperationsStruct, fuse_operations.rmdir.allocate(this::rmdir, fuseScope).address());
+			case STATFS -> fuse_operations.statfs$set(fuseOperationsStruct, fuse_operations.statfs.allocate(this::statfs, fuseScope).address());
+			case SYMLINK -> fuse_operations.symlink$set(fuseOperationsStruct, fuse_operations.symlink.allocate(this::symlink, fuseScope).address());
+			case TRUNCATE -> fuse_operations.truncate$set(fuseOperationsStruct, fuse_operations.truncate.allocate(this::truncate, fuseScope).address());
+			case UNLINK -> fuse_operations.unlink$set(fuseOperationsStruct, fuse_operations.unlink.allocate(this::unlink, fuseScope).address());
+			case UTIMENS -> fuse_operations.utimens$set(fuseOperationsStruct, fuse_operations.utimens.allocate(this::utimens, fuseScope).address());
+			case WRITE -> fuse_operations.write$set(fuseOperationsStruct, fuse_operations.write.allocate(this::write, fuseScope).address());
 		}
 	}
 

--- a/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/FuseImpl.java
+++ b/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/FuseImpl.java
@@ -34,7 +34,7 @@ final class FuseImpl extends Fuse {
 		if (MemoryAddress.NULL.equals(ch)) {
 			throw new MountFailedException("fuse_mount failed");
 		}
-		var fuse = fuse_h.fuse_new(ch, fuseArgs.args(), segment, segment.byteSize(), MemoryAddress.NULL);
+		var fuse = fuse_h.fuse_new(ch, fuseArgs.args(), fuseOperationsStruct, fuseOperationsStruct.byteSize(), MemoryAddress.NULL);
 		if (MemoryAddress.NULL.equals(fuse)) {
 			fuse_h.fuse_unmount(fuseArgs.mountPoint(), ch);
 			throw new MountFailedException("fuse_new failed");
@@ -71,38 +71,38 @@ final class FuseImpl extends Fuse {
 	@Override
 	protected void bind(FuseOperations.Operation operation) {
 		switch (operation) {
-			case INIT -> fuse_operations.init$set(segment, fuse_operations.init.allocate(this::init, fuseScope).address());
-			case ACCESS -> fuse_operations.access$set(segment, fuse_operations.access.allocate(this::access, fuseScope).address());
-			case CHMOD -> fuse_operations.chmod$set(segment, fuse_operations.chmod.allocate(this::chmod, fuseScope).address());
-			case CHOWN -> fuse_operations.chown$set(segment, fuse_operations.chown.allocate(this::chown, fuseScope).address());
-			case CREATE -> fuse_operations.create$set(segment, fuse_operations.create.allocate(this::create, fuseScope).address());
-			case DESTROY -> fuse_operations.destroy$set(segment, fuse_operations.destroy.allocate(this::destroy, fuseScope).address());
-			case FLUSH -> fuse_operations.flush$set(segment, fuse_operations.flush.allocate(this::flush, fuseScope).address());
-			case FSYNC -> fuse_operations.fsync$set(segment, fuse_operations.fsync.allocate(this::fsync, fuseScope).address());
-			case FSYNCDIR -> fuse_operations.fsyncdir$set(segment, fuse_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
+			case INIT -> fuse_operations.init$set(fuseOperationsStruct, fuse_operations.init.allocate(this::init, fuseScope).address());
+			case ACCESS -> fuse_operations.access$set(fuseOperationsStruct, fuse_operations.access.allocate(this::access, fuseScope).address());
+			case CHMOD -> fuse_operations.chmod$set(fuseOperationsStruct, fuse_operations.chmod.allocate(this::chmod, fuseScope).address());
+			case CHOWN -> fuse_operations.chown$set(fuseOperationsStruct, fuse_operations.chown.allocate(this::chown, fuseScope).address());
+			case CREATE -> fuse_operations.create$set(fuseOperationsStruct, fuse_operations.create.allocate(this::create, fuseScope).address());
+			case DESTROY -> fuse_operations.destroy$set(fuseOperationsStruct, fuse_operations.destroy.allocate(this::destroy, fuseScope).address());
+			case FLUSH -> fuse_operations.flush$set(fuseOperationsStruct, fuse_operations.flush.allocate(this::flush, fuseScope).address());
+			case FSYNC -> fuse_operations.fsync$set(fuseOperationsStruct, fuse_operations.fsync.allocate(this::fsync, fuseScope).address());
+			case FSYNCDIR -> fuse_operations.fsyncdir$set(fuseOperationsStruct, fuse_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
 			case GET_ATTR -> {
-				fuse_operations.getattr$set(segment, fuse_operations.getattr.allocate(this::getattr, fuseScope).address());
-				fuse_operations.fgetattr$set(segment, fuse_operations.fgetattr.allocate(this::fgetattr, fuseScope).address());
+				fuse_operations.getattr$set(fuseOperationsStruct, fuse_operations.getattr.allocate(this::getattr, fuseScope).address());
+				fuse_operations.fgetattr$set(fuseOperationsStruct, fuse_operations.fgetattr.allocate(this::fgetattr, fuseScope).address());
 			}
-			case MKDIR -> fuse_operations.mkdir$set(segment, fuse_operations.mkdir.allocate(this::mkdir, fuseScope).address());
-			case OPEN -> fuse_operations.open$set(segment, fuse_operations.open.allocate(this::open, fuseScope).address());
-			case OPEN_DIR -> fuse_operations.opendir$set(segment, fuse_operations.opendir.allocate(this::opendir, fuseScope).address());
-			case READ -> fuse_operations.read$set(segment, fuse_operations.read.allocate(this::read, fuseScope).address());
-			case READ_DIR -> fuse_operations.readdir$set(segment, fuse_operations.readdir.allocate(this::readdir, fuseScope).address());
-			case READLINK -> fuse_operations.readlink$set(segment, fuse_operations.readlink.allocate(this::readlink, fuseScope).address());
-			case RELEASE -> fuse_operations.release$set(segment, fuse_operations.release.allocate(this::release, fuseScope).address());
-			case RELEASE_DIR -> fuse_operations.releasedir$set(segment, fuse_operations.releasedir.allocate(this::releasedir, fuseScope).address());
-			case RENAME -> fuse_operations.rename$set(segment, fuse_operations.rename.allocate(this::rename, fuseScope).address());
-			case RMDIR -> fuse_operations.rmdir$set(segment, fuse_operations.rmdir.allocate(this::rmdir, fuseScope).address());
-			case STATFS -> fuse_operations.statfs$set(segment, fuse_operations.statfs.allocate(this::statfs, fuseScope).address());
-			case SYMLINK -> fuse_operations.symlink$set(segment, fuse_operations.symlink.allocate(this::symlink, fuseScope).address());
+			case MKDIR -> fuse_operations.mkdir$set(fuseOperationsStruct, fuse_operations.mkdir.allocate(this::mkdir, fuseScope).address());
+			case OPEN -> fuse_operations.open$set(fuseOperationsStruct, fuse_operations.open.allocate(this::open, fuseScope).address());
+			case OPEN_DIR -> fuse_operations.opendir$set(fuseOperationsStruct, fuse_operations.opendir.allocate(this::opendir, fuseScope).address());
+			case READ -> fuse_operations.read$set(fuseOperationsStruct, fuse_operations.read.allocate(this::read, fuseScope).address());
+			case READ_DIR -> fuse_operations.readdir$set(fuseOperationsStruct, fuse_operations.readdir.allocate(this::readdir, fuseScope).address());
+			case READLINK -> fuse_operations.readlink$set(fuseOperationsStruct, fuse_operations.readlink.allocate(this::readlink, fuseScope).address());
+			case RELEASE -> fuse_operations.release$set(fuseOperationsStruct, fuse_operations.release.allocate(this::release, fuseScope).address());
+			case RELEASE_DIR -> fuse_operations.releasedir$set(fuseOperationsStruct, fuse_operations.releasedir.allocate(this::releasedir, fuseScope).address());
+			case RENAME -> fuse_operations.rename$set(fuseOperationsStruct, fuse_operations.rename.allocate(this::rename, fuseScope).address());
+			case RMDIR -> fuse_operations.rmdir$set(fuseOperationsStruct, fuse_operations.rmdir.allocate(this::rmdir, fuseScope).address());
+			case STATFS -> fuse_operations.statfs$set(fuseOperationsStruct, fuse_operations.statfs.allocate(this::statfs, fuseScope).address());
+			case SYMLINK -> fuse_operations.symlink$set(fuseOperationsStruct, fuse_operations.symlink.allocate(this::symlink, fuseScope).address());
 			case TRUNCATE -> {
-				fuse_operations.truncate$set(segment, fuse_operations.truncate.allocate(this::truncate, fuseScope).address());
-				fuse_operations.ftruncate$set(segment, fuse_operations.ftruncate.allocate(this::ftruncate, fuseScope).address());
+				fuse_operations.truncate$set(fuseOperationsStruct, fuse_operations.truncate.allocate(this::truncate, fuseScope).address());
+				fuse_operations.ftruncate$set(fuseOperationsStruct, fuse_operations.ftruncate.allocate(this::ftruncate, fuseScope).address());
 			}
-			case UNLINK -> fuse_operations.unlink$set(segment, fuse_operations.unlink.allocate(this::unlink, fuseScope).address());
-			case UTIMENS -> fuse_operations.utimens$set(segment, fuse_operations.utimens.allocate(this::utimens, fuseScope).address());
-			case WRITE -> fuse_operations.write$set(segment, fuse_operations.write.allocate(this::write, fuseScope).address());
+			case UNLINK -> fuse_operations.unlink$set(fuseOperationsStruct, fuse_operations.unlink.allocate(this::unlink, fuseScope).address());
+			case UTIMENS -> fuse_operations.utimens$set(fuseOperationsStruct, fuse_operations.utimens.allocate(this::utimens, fuseScope).address());
+			case WRITE -> fuse_operations.write$set(fuseOperationsStruct, fuse_operations.write.allocate(this::write, fuseScope).address());
 		}
 	}
 

--- a/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/FuseImpl.java
+++ b/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/FuseImpl.java
@@ -25,7 +25,6 @@ final class FuseImpl extends Fuse {
 
 	public FuseImpl(FuseOperations fuseOperations) {
 		super(fuseOperations, fuse_operations::allocate);
-		fuseOperations.supportedOperations().forEach(this::bind);
 	}
 
 	@Override
@@ -69,7 +68,8 @@ final class FuseImpl extends Fuse {
 		return new FuseArgs(args, mountPoint, isMultiThreaded);
 	}
 
-	private void bind(FuseOperations.Operation operation) {
+	@Override
+	protected void bind(FuseOperations.Operation operation) {
 		switch (operation) {
 			case INIT -> fuse_operations.init$set(segment, fuse_operations.init.allocate(this::init, fuseScope).address());
 			case ACCESS -> fuse_operations.access$set(segment, fuse_operations.access.allocate(this::access, fuseScope).address());

--- a/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/FuseImpl.java
+++ b/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/FuseImpl.java
@@ -160,14 +160,14 @@ final class FuseImpl extends Fuse {
 	@VisibleForTesting
 	int getattr(MemoryAddress path, MemoryAddress stat) {
 		try (var scope = MemorySession.openConfined()) {
-			return this.getattr(path.getUtf8String(0), new StatImpl(stat, scope), null);
+			return fuseOperations.getattr(path.getUtf8String(0), new StatImpl(stat, scope), null);
 		}
 	}
 
 	@VisibleForTesting
 	int fgetattr(MemoryAddress path, MemoryAddress stat, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return this.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
+			return fuseOperations.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
 		}
 	}
 

--- a/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/FuseImpl.java
+++ b/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/FuseImpl.java
@@ -11,57 +11,24 @@ import org.cryptomator.jfuse.mac.extr.stat_h;
 import org.cryptomator.jfuse.mac.extr.timespec;
 import org.jetbrains.annotations.VisibleForTesting;
 
-import java.io.IOException;
 import java.lang.foreign.Addressable;
 import java.lang.foreign.MemoryAddress;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySession;
 import java.lang.foreign.ValueLayout;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.attribute.BasicFileAttributeView;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 final class FuseImpl extends Fuse {
 
-	//Used to check, if the mounted fs is actually accessible
-	private static final String MOUNT_PROBE = "/jfuse_mac_mount_probe";
-	private final FuseOperations delegate;
-	private final MemorySegment fuseOps;
-
-	private final CountDownLatch mountProbeSucceeded = new CountDownLatch(1);
+	private final MemorySegment segment;
 
 	public FuseImpl(FuseOperations fuseOperations) {
-		this.fuseOps = fuse_operations.allocate(fuseScope);
-		this.delegate = fuseOperations;
+		super(fuseOperations);
+		this.segment = fuse_operations.allocate(fuseScope);
 		fuseOperations.supportedOperations().forEach(this::bind);
-	}
-
-	@Override
-	public void mount(String progName, Path mountPoint, String... flags) throws MountFailedException, IllegalArgumentException {
-		super.mount(progName, mountPoint, flags);
-		try {
-			waitForMountingToComplete(mountPoint);
-		} catch (InterruptedException e) {
-			Thread.currentThread().interrupt();
-			throw new MountFailedException("Interrupted while waiting for mounting to finish");
-		}
-	}
-
-	void waitForMountingToComplete(Path mountPoint) throws InterruptedException {
-		var probe = Files.getFileAttributeView(mountPoint.resolve(MOUNT_PROBE.substring(1)), BasicFileAttributeView.class);
-		do {
-			try {
-				probe.readAttributes(); // we don't care about the result, we just want to trigger a getattr call
-			} catch (IOException e) {
-				//noop
-			}
-		} while (!mountProbeSucceeded.await(333, TimeUnit.MILLISECONDS));
 	}
 
 	@Override
@@ -71,7 +38,7 @@ final class FuseImpl extends Fuse {
 		if (MemoryAddress.NULL.equals(ch)) {
 			throw new MountFailedException("fuse_mount failed");
 		}
-		var fuse = fuse_h.fuse_new(ch, fuseArgs.args(), fuseOps, fuseOps.byteSize(), MemoryAddress.NULL);
+		var fuse = fuse_h.fuse_new(ch, fuseArgs.args(), segment, segment.byteSize(), MemoryAddress.NULL);
 		if (MemoryAddress.NULL.equals(fuse)) {
 			fuse_h.fuse_unmount(fuseArgs.mountPoint(), ch);
 			throw new MountFailedException("fuse_new failed");
@@ -107,190 +74,186 @@ final class FuseImpl extends Fuse {
 
 	private void bind(FuseOperations.Operation operation) {
 		switch (operation) {
-			case INIT -> fuse_operations.init$set(fuseOps, fuse_operations.init.allocate(this::init, fuseScope).address());
-			case ACCESS -> fuse_operations.access$set(fuseOps, fuse_operations.access.allocate(this::access, fuseScope).address());
-			case CHMOD -> fuse_operations.chmod$set(fuseOps, fuse_operations.chmod.allocate(this::chmod, fuseScope).address());
-			case CHOWN -> fuse_operations.chown$set(fuseOps, fuse_operations.chown.allocate(this::chown, fuseScope).address());
-			case CREATE -> fuse_operations.create$set(fuseOps, fuse_operations.create.allocate(this::create, fuseScope).address());
-			case DESTROY -> fuse_operations.destroy$set(fuseOps, fuse_operations.destroy.allocate(this::destroy, fuseScope).address());
-			case FLUSH -> fuse_operations.flush$set(fuseOps, fuse_operations.flush.allocate(this::flush, fuseScope).address());
-			case FSYNC -> fuse_operations.fsync$set(fuseOps, fuse_operations.fsync.allocate(this::fsync, fuseScope).address());
-			case FSYNCDIR -> fuse_operations.fsyncdir$set(fuseOps, fuse_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
+			case INIT -> fuse_operations.init$set(segment, fuse_operations.init.allocate(this::init, fuseScope).address());
+			case ACCESS -> fuse_operations.access$set(segment, fuse_operations.access.allocate(this::access, fuseScope).address());
+			case CHMOD -> fuse_operations.chmod$set(segment, fuse_operations.chmod.allocate(this::chmod, fuseScope).address());
+			case CHOWN -> fuse_operations.chown$set(segment, fuse_operations.chown.allocate(this::chown, fuseScope).address());
+			case CREATE -> fuse_operations.create$set(segment, fuse_operations.create.allocate(this::create, fuseScope).address());
+			case DESTROY -> fuse_operations.destroy$set(segment, fuse_operations.destroy.allocate(this::destroy, fuseScope).address());
+			case FLUSH -> fuse_operations.flush$set(segment, fuse_operations.flush.allocate(this::flush, fuseScope).address());
+			case FSYNC -> fuse_operations.fsync$set(segment, fuse_operations.fsync.allocate(this::fsync, fuseScope).address());
+			case FSYNCDIR -> fuse_operations.fsyncdir$set(segment, fuse_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
 			case GET_ATTR -> {
-				fuse_operations.getattr$set(fuseOps, fuse_operations.getattr.allocate(this::getattr, fuseScope).address());
-				fuse_operations.fgetattr$set(fuseOps, fuse_operations.fgetattr.allocate(this::fgetattr, fuseScope).address());
+				fuse_operations.getattr$set(segment, fuse_operations.getattr.allocate(this::getattr, fuseScope).address());
+				fuse_operations.fgetattr$set(segment, fuse_operations.fgetattr.allocate(this::fgetattr, fuseScope).address());
 			}
-			case MKDIR -> fuse_operations.mkdir$set(fuseOps, fuse_operations.mkdir.allocate(this::mkdir, fuseScope).address());
-			case OPEN -> fuse_operations.open$set(fuseOps, fuse_operations.open.allocate(this::open, fuseScope).address());
-			case OPEN_DIR -> fuse_operations.opendir$set(fuseOps, fuse_operations.opendir.allocate(this::opendir, fuseScope).address());
-			case READ -> fuse_operations.read$set(fuseOps, fuse_operations.read.allocate(this::read, fuseScope).address());
-			case READ_DIR -> fuse_operations.readdir$set(fuseOps, fuse_operations.readdir.allocate(this::readdir, fuseScope).address());
-			case READLINK -> fuse_operations.readlink$set(fuseOps, fuse_operations.readlink.allocate(this::readlink, fuseScope).address());
-			case RELEASE -> fuse_operations.release$set(fuseOps, fuse_operations.release.allocate(this::release, fuseScope).address());
-			case RELEASE_DIR -> fuse_operations.releasedir$set(fuseOps, fuse_operations.releasedir.allocate(this::releasedir, fuseScope).address());
-			case RENAME -> fuse_operations.rename$set(fuseOps, fuse_operations.rename.allocate(this::rename, fuseScope).address());
-			case RMDIR -> fuse_operations.rmdir$set(fuseOps, fuse_operations.rmdir.allocate(this::rmdir, fuseScope).address());
-			case STATFS -> fuse_operations.statfs$set(fuseOps, fuse_operations.statfs.allocate(this::statfs, fuseScope).address());
-			case SYMLINK -> fuse_operations.symlink$set(fuseOps, fuse_operations.symlink.allocate(this::symlink, fuseScope).address());
+			case MKDIR -> fuse_operations.mkdir$set(segment, fuse_operations.mkdir.allocate(this::mkdir, fuseScope).address());
+			case OPEN -> fuse_operations.open$set(segment, fuse_operations.open.allocate(this::open, fuseScope).address());
+			case OPEN_DIR -> fuse_operations.opendir$set(segment, fuse_operations.opendir.allocate(this::opendir, fuseScope).address());
+			case READ -> fuse_operations.read$set(segment, fuse_operations.read.allocate(this::read, fuseScope).address());
+			case READ_DIR -> fuse_operations.readdir$set(segment, fuse_operations.readdir.allocate(this::readdir, fuseScope).address());
+			case READLINK -> fuse_operations.readlink$set(segment, fuse_operations.readlink.allocate(this::readlink, fuseScope).address());
+			case RELEASE -> fuse_operations.release$set(segment, fuse_operations.release.allocate(this::release, fuseScope).address());
+			case RELEASE_DIR -> fuse_operations.releasedir$set(segment, fuse_operations.releasedir.allocate(this::releasedir, fuseScope).address());
+			case RENAME -> fuse_operations.rename$set(segment, fuse_operations.rename.allocate(this::rename, fuseScope).address());
+			case RMDIR -> fuse_operations.rmdir$set(segment, fuse_operations.rmdir.allocate(this::rmdir, fuseScope).address());
+			case STATFS -> fuse_operations.statfs$set(segment, fuse_operations.statfs.allocate(this::statfs, fuseScope).address());
+			case SYMLINK -> fuse_operations.symlink$set(segment, fuse_operations.symlink.allocate(this::symlink, fuseScope).address());
 			case TRUNCATE -> {
-				fuse_operations.truncate$set(fuseOps, fuse_operations.truncate.allocate(this::truncate, fuseScope).address());
-				fuse_operations.ftruncate$set(fuseOps, fuse_operations.ftruncate.allocate(this::ftruncate, fuseScope).address());
+				fuse_operations.truncate$set(segment, fuse_operations.truncate.allocate(this::truncate, fuseScope).address());
+				fuse_operations.ftruncate$set(segment, fuse_operations.ftruncate.allocate(this::ftruncate, fuseScope).address());
 			}
-			case UNLINK -> fuse_operations.unlink$set(fuseOps, fuse_operations.unlink.allocate(this::unlink, fuseScope).address());
-			case UTIMENS -> fuse_operations.utimens$set(fuseOps, fuse_operations.utimens.allocate(this::utimens, fuseScope).address());
-			case WRITE -> fuse_operations.write$set(fuseOps, fuse_operations.write.allocate(this::write, fuseScope).address());
+			case UNLINK -> fuse_operations.unlink$set(segment, fuse_operations.unlink.allocate(this::unlink, fuseScope).address());
+			case UTIMENS -> fuse_operations.utimens$set(segment, fuse_operations.utimens.allocate(this::utimens, fuseScope).address());
+			case WRITE -> fuse_operations.write$set(segment, fuse_operations.write.allocate(this::write, fuseScope).address());
 		}
 	}
 
 	private Addressable init(MemoryAddress conn) {
 		try (var scope = MemorySession.openConfined()) {
-			delegate.init(new FuseConnInfoImpl(conn, scope), null);
+			fuseOperations.init(new FuseConnInfoImpl(conn, scope), null);
 		}
 		return MemoryAddress.NULL;
 	}
 
 	private int access(MemoryAddress path, int mask) {
-		return delegate.access(path.getUtf8String(0), mask);
+		return fuseOperations.access(path.getUtf8String(0), mask);
 	}
 
 	private int chmod(MemoryAddress path, short mode) {
-		return delegate.chmod(path.getUtf8String(0), mode, null);
+		return fuseOperations.chmod(path.getUtf8String(0), mode, null);
 	}
 
 	@VisibleForTesting
 	int chown(MemoryAddress path, int uid, int gid) {
-		return delegate.chown(path.getUtf8String(0), uid, gid, null);
+		return fuseOperations.chown(path.getUtf8String(0), uid, gid, null);
 	}
 
 	private int create(MemoryAddress path, short mode, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.create(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
+			return fuseOperations.create(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private void destroy(MemoryAddress addr) {
-		delegate.destroy();
+		fuseOperations.destroy();
 	}
 
 	@VisibleForTesting
 	int flush(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.flush(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return fuseOperations.flush(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	@VisibleForTesting
 	int fsync(MemoryAddress path, int datasync, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.fsync(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
+			return fuseOperations.fsync(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	@VisibleForTesting
 	int fsyncdir(MemoryAddress path, int datasync, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.fsyncdir(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
+			return fuseOperations.fsyncdir(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	@VisibleForTesting
 	int getattr(MemoryAddress path, MemoryAddress stat) {
 		try (var scope = MemorySession.openConfined()) {
-			var pathObj = path.getUtf8String(0);
-			if(mountProbeSucceeded.getCount() > 0 && pathObj.equals(MOUNT_PROBE) ) {
-				mountProbeSucceeded.countDown();
-			}
-			return delegate.getattr(path.getUtf8String(0), new StatImpl(stat, scope), null);
+			return this.getattr(path.getUtf8String(0), new StatImpl(stat, scope), null);
 		}
 	}
 
 	@VisibleForTesting
 	int fgetattr(MemoryAddress path, MemoryAddress stat, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
+			return this.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int mkdir(MemoryAddress path, short mode) {
-		return delegate.mkdir(path.getUtf8String(0), mode);
+		return fuseOperations.mkdir(path.getUtf8String(0), mode);
 	}
 
 	private int open(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.open(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return fuseOperations.open(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int opendir(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.opendir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return fuseOperations.opendir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int read(MemoryAddress path, MemoryAddress buf, long size, long offset, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
 			var buffer = MemorySegment.ofAddress(buf, size, scope).asByteBuffer();
-			return delegate.read(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
+			return fuseOperations.read(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int readdir(MemoryAddress path, MemoryAddress buf, MemoryAddress filler, long offset, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.readdir(path.getUtf8String(0), new DirFillerImpl(buf, filler, scope), offset, new FileInfoImpl(fi, scope), 0);
+			return fuseOperations.readdir(path.getUtf8String(0), new DirFillerImpl(buf, filler, scope), offset, new FileInfoImpl(fi, scope), 0);
 		}
 	}
 
 	private int readlink(MemoryAddress path, MemoryAddress buf, long len) {
 		try (var scope = MemorySession.openConfined()) {
 			var buffer = MemorySegment.ofAddress(buf, len, scope).asByteBuffer();
-			return delegate.readlink(path.getUtf8String(0), buffer, len);
+			return fuseOperations.readlink(path.getUtf8String(0), buffer, len);
 		}
 	}
 
 	private int release(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.release(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return fuseOperations.release(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int releasedir(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.releasedir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return fuseOperations.releasedir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int rename(MemoryAddress oldpath, MemoryAddress newpath) {
-		return delegate.rename(oldpath.getUtf8String(0), newpath.getUtf8String(0), 0);
+		return fuseOperations.rename(oldpath.getUtf8String(0), newpath.getUtf8String(0), 0);
 	}
 
 	private int rmdir(MemoryAddress path) {
-		return delegate.rmdir(path.getUtf8String(0));
+		return fuseOperations.rmdir(path.getUtf8String(0));
 	}
 
 	private int statfs(MemoryAddress path, MemoryAddress statvfs) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.statfs(path.getUtf8String(0), new StatvfsImpl(statvfs, scope));
+			return fuseOperations.statfs(path.getUtf8String(0), new StatvfsImpl(statvfs, scope));
 		}
 	}
 
 	private int symlink(MemoryAddress linkname, MemoryAddress target) {
-		return delegate.symlink(linkname.getUtf8String(0), target.getUtf8String(0));
+		return fuseOperations.symlink(linkname.getUtf8String(0), target.getUtf8String(0));
 	}
 
 	@VisibleForTesting
 	int truncate(MemoryAddress path, long size) {
-		return delegate.truncate(path.getUtf8String(0), size, null);
+		return fuseOperations.truncate(path.getUtf8String(0), size, null);
 	}
 
 	@VisibleForTesting
 	int ftruncate(MemoryAddress path, long size, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.truncate(path.getUtf8String(0), size, new FileInfoImpl(fi, scope));
+			return fuseOperations.truncate(path.getUtf8String(0), size, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int unlink(MemoryAddress path) {
-		return delegate.unlink(path.getUtf8String(0));
+		return fuseOperations.unlink(path.getUtf8String(0));
 	}
 
 	@VisibleForTesting
@@ -302,13 +265,13 @@ final class FuseImpl extends Fuse {
 				timespec.tv_sec$set(segment, 0);
 				timespec.tv_nsec$set(segment, stat_h.UTIME_NOW());
 				var time = new TimeSpecImpl(segment);
-				return delegate.utimens(path.getUtf8String(0), time, time, null);
+				return fuseOperations.utimens(path.getUtf8String(0), time, time, null);
 			} else {
 				var seq = MemoryLayout.sequenceLayout(2, timespec.$LAYOUT());
 				var segment = MemorySegment.ofAddress(times, seq.byteSize(), scope);
 				var time0 = segment.asSlice(0, timespec.$LAYOUT().byteSize());
 				var time1 = segment.asSlice(timespec.$LAYOUT().byteSize(), timespec.$LAYOUT().byteSize());
-				return delegate.utimens(path.getUtf8String(0), new TimeSpecImpl(time0), new TimeSpecImpl(time1), null);
+				return fuseOperations.utimens(path.getUtf8String(0), new TimeSpecImpl(time0), new TimeSpecImpl(time1), null);
 			}
 		}
 	}
@@ -316,7 +279,7 @@ final class FuseImpl extends Fuse {
 	private int write(MemoryAddress path, MemoryAddress buf, long size, long offset, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
 			var buffer = MemorySegment.ofAddress(buf, size, scope).asByteBuffer();
-			return delegate.write(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
+			return fuseOperations.write(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
 		}
 	}
 

--- a/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/FuseImpl.java
+++ b/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/FuseImpl.java
@@ -34,7 +34,7 @@ final class FuseImpl extends Fuse {
 		if (MemoryAddress.NULL.equals(ch)) {
 			throw new MountFailedException("fuse_mount failed");
 		}
-		var fuse = fuse_h.fuse_new(ch, fuseArgs.args(), fuseOperationsStruct, fuseOperationsStruct.byteSize(), MemoryAddress.NULL);
+		var fuse = fuse_h.fuse_new(ch, fuseArgs.args(), fuseOps, fuseOps.byteSize(), MemoryAddress.NULL);
 		if (MemoryAddress.NULL.equals(fuse)) {
 			fuse_h.fuse_unmount(fuseArgs.mountPoint(), ch);
 			throw new MountFailedException("fuse_new failed");
@@ -71,186 +71,186 @@ final class FuseImpl extends Fuse {
 	@Override
 	protected void bind(FuseOperations.Operation operation) {
 		switch (operation) {
-			case INIT -> fuse_operations.init$set(fuseOperationsStruct, fuse_operations.init.allocate(this::init, fuseScope).address());
-			case ACCESS -> fuse_operations.access$set(fuseOperationsStruct, fuse_operations.access.allocate(this::access, fuseScope).address());
-			case CHMOD -> fuse_operations.chmod$set(fuseOperationsStruct, fuse_operations.chmod.allocate(this::chmod, fuseScope).address());
-			case CHOWN -> fuse_operations.chown$set(fuseOperationsStruct, fuse_operations.chown.allocate(this::chown, fuseScope).address());
-			case CREATE -> fuse_operations.create$set(fuseOperationsStruct, fuse_operations.create.allocate(this::create, fuseScope).address());
-			case DESTROY -> fuse_operations.destroy$set(fuseOperationsStruct, fuse_operations.destroy.allocate(this::destroy, fuseScope).address());
-			case FLUSH -> fuse_operations.flush$set(fuseOperationsStruct, fuse_operations.flush.allocate(this::flush, fuseScope).address());
-			case FSYNC -> fuse_operations.fsync$set(fuseOperationsStruct, fuse_operations.fsync.allocate(this::fsync, fuseScope).address());
-			case FSYNCDIR -> fuse_operations.fsyncdir$set(fuseOperationsStruct, fuse_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
+			case INIT -> fuse_operations.init$set(fuseOps, fuse_operations.init.allocate(this::init, fuseScope).address());
+			case ACCESS -> fuse_operations.access$set(fuseOps, fuse_operations.access.allocate(this::access, fuseScope).address());
+			case CHMOD -> fuse_operations.chmod$set(fuseOps, fuse_operations.chmod.allocate(this::chmod, fuseScope).address());
+			case CHOWN -> fuse_operations.chown$set(fuseOps, fuse_operations.chown.allocate(this::chown, fuseScope).address());
+			case CREATE -> fuse_operations.create$set(fuseOps, fuse_operations.create.allocate(this::create, fuseScope).address());
+			case DESTROY -> fuse_operations.destroy$set(fuseOps, fuse_operations.destroy.allocate(this::destroy, fuseScope).address());
+			case FLUSH -> fuse_operations.flush$set(fuseOps, fuse_operations.flush.allocate(this::flush, fuseScope).address());
+			case FSYNC -> fuse_operations.fsync$set(fuseOps, fuse_operations.fsync.allocate(this::fsync, fuseScope).address());
+			case FSYNCDIR -> fuse_operations.fsyncdir$set(fuseOps, fuse_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
 			case GET_ATTR -> {
-				fuse_operations.getattr$set(fuseOperationsStruct, fuse_operations.getattr.allocate(this::getattr, fuseScope).address());
-				fuse_operations.fgetattr$set(fuseOperationsStruct, fuse_operations.fgetattr.allocate(this::fgetattr, fuseScope).address());
+				fuse_operations.getattr$set(fuseOps, fuse_operations.getattr.allocate(this::getattr, fuseScope).address());
+				fuse_operations.fgetattr$set(fuseOps, fuse_operations.fgetattr.allocate(this::fgetattr, fuseScope).address());
 			}
-			case MKDIR -> fuse_operations.mkdir$set(fuseOperationsStruct, fuse_operations.mkdir.allocate(this::mkdir, fuseScope).address());
-			case OPEN -> fuse_operations.open$set(fuseOperationsStruct, fuse_operations.open.allocate(this::open, fuseScope).address());
-			case OPEN_DIR -> fuse_operations.opendir$set(fuseOperationsStruct, fuse_operations.opendir.allocate(this::opendir, fuseScope).address());
-			case READ -> fuse_operations.read$set(fuseOperationsStruct, fuse_operations.read.allocate(this::read, fuseScope).address());
-			case READ_DIR -> fuse_operations.readdir$set(fuseOperationsStruct, fuse_operations.readdir.allocate(this::readdir, fuseScope).address());
-			case READLINK -> fuse_operations.readlink$set(fuseOperationsStruct, fuse_operations.readlink.allocate(this::readlink, fuseScope).address());
-			case RELEASE -> fuse_operations.release$set(fuseOperationsStruct, fuse_operations.release.allocate(this::release, fuseScope).address());
-			case RELEASE_DIR -> fuse_operations.releasedir$set(fuseOperationsStruct, fuse_operations.releasedir.allocate(this::releasedir, fuseScope).address());
-			case RENAME -> fuse_operations.rename$set(fuseOperationsStruct, fuse_operations.rename.allocate(this::rename, fuseScope).address());
-			case RMDIR -> fuse_operations.rmdir$set(fuseOperationsStruct, fuse_operations.rmdir.allocate(this::rmdir, fuseScope).address());
-			case STATFS -> fuse_operations.statfs$set(fuseOperationsStruct, fuse_operations.statfs.allocate(this::statfs, fuseScope).address());
-			case SYMLINK -> fuse_operations.symlink$set(fuseOperationsStruct, fuse_operations.symlink.allocate(this::symlink, fuseScope).address());
+			case MKDIR -> fuse_operations.mkdir$set(fuseOps, fuse_operations.mkdir.allocate(this::mkdir, fuseScope).address());
+			case OPEN -> fuse_operations.open$set(fuseOps, fuse_operations.open.allocate(this::open, fuseScope).address());
+			case OPEN_DIR -> fuse_operations.opendir$set(fuseOps, fuse_operations.opendir.allocate(this::opendir, fuseScope).address());
+			case READ -> fuse_operations.read$set(fuseOps, fuse_operations.read.allocate(this::read, fuseScope).address());
+			case READ_DIR -> fuse_operations.readdir$set(fuseOps, fuse_operations.readdir.allocate(this::readdir, fuseScope).address());
+			case READLINK -> fuse_operations.readlink$set(fuseOps, fuse_operations.readlink.allocate(this::readlink, fuseScope).address());
+			case RELEASE -> fuse_operations.release$set(fuseOps, fuse_operations.release.allocate(this::release, fuseScope).address());
+			case RELEASE_DIR -> fuse_operations.releasedir$set(fuseOps, fuse_operations.releasedir.allocate(this::releasedir, fuseScope).address());
+			case RENAME -> fuse_operations.rename$set(fuseOps, fuse_operations.rename.allocate(this::rename, fuseScope).address());
+			case RMDIR -> fuse_operations.rmdir$set(fuseOps, fuse_operations.rmdir.allocate(this::rmdir, fuseScope).address());
+			case STATFS -> fuse_operations.statfs$set(fuseOps, fuse_operations.statfs.allocate(this::statfs, fuseScope).address());
+			case SYMLINK -> fuse_operations.symlink$set(fuseOps, fuse_operations.symlink.allocate(this::symlink, fuseScope).address());
 			case TRUNCATE -> {
-				fuse_operations.truncate$set(fuseOperationsStruct, fuse_operations.truncate.allocate(this::truncate, fuseScope).address());
-				fuse_operations.ftruncate$set(fuseOperationsStruct, fuse_operations.ftruncate.allocate(this::ftruncate, fuseScope).address());
+				fuse_operations.truncate$set(fuseOps, fuse_operations.truncate.allocate(this::truncate, fuseScope).address());
+				fuse_operations.ftruncate$set(fuseOps, fuse_operations.ftruncate.allocate(this::ftruncate, fuseScope).address());
 			}
-			case UNLINK -> fuse_operations.unlink$set(fuseOperationsStruct, fuse_operations.unlink.allocate(this::unlink, fuseScope).address());
-			case UTIMENS -> fuse_operations.utimens$set(fuseOperationsStruct, fuse_operations.utimens.allocate(this::utimens, fuseScope).address());
-			case WRITE -> fuse_operations.write$set(fuseOperationsStruct, fuse_operations.write.allocate(this::write, fuseScope).address());
+			case UNLINK -> fuse_operations.unlink$set(fuseOps, fuse_operations.unlink.allocate(this::unlink, fuseScope).address());
+			case UTIMENS -> fuse_operations.utimens$set(fuseOps, fuse_operations.utimens.allocate(this::utimens, fuseScope).address());
+			case WRITE -> fuse_operations.write$set(fuseOps, fuse_operations.write.allocate(this::write, fuseScope).address());
 		}
 	}
 
 	private Addressable init(MemoryAddress conn) {
 		try (var scope = MemorySession.openConfined()) {
-			fuseOperations.init(new FuseConnInfoImpl(conn, scope), null);
+			delegate.init(new FuseConnInfoImpl(conn, scope), null);
 		}
 		return MemoryAddress.NULL;
 	}
 
 	private int access(MemoryAddress path, int mask) {
-		return fuseOperations.access(path.getUtf8String(0), mask);
+		return delegate.access(path.getUtf8String(0), mask);
 	}
 
 	private int chmod(MemoryAddress path, short mode) {
-		return fuseOperations.chmod(path.getUtf8String(0), mode, null);
+		return delegate.chmod(path.getUtf8String(0), mode, null);
 	}
 
 	@VisibleForTesting
 	int chown(MemoryAddress path, int uid, int gid) {
-		return fuseOperations.chown(path.getUtf8String(0), uid, gid, null);
+		return delegate.chown(path.getUtf8String(0), uid, gid, null);
 	}
 
 	private int create(MemoryAddress path, short mode, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.create(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
+			return delegate.create(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private void destroy(MemoryAddress addr) {
-		fuseOperations.destroy();
+		delegate.destroy();
 	}
 
 	@VisibleForTesting
 	int flush(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.flush(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return delegate.flush(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	@VisibleForTesting
 	int fsync(MemoryAddress path, int datasync, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.fsync(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
+			return delegate.fsync(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	@VisibleForTesting
 	int fsyncdir(MemoryAddress path, int datasync, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.fsyncdir(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
+			return delegate.fsyncdir(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	@VisibleForTesting
 	int getattr(MemoryAddress path, MemoryAddress stat) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.getattr(path.getUtf8String(0), new StatImpl(stat, scope), null);
+			return delegate.getattr(path.getUtf8String(0), new StatImpl(stat, scope), null);
 		}
 	}
 
 	@VisibleForTesting
 	int fgetattr(MemoryAddress path, MemoryAddress stat, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
+			return delegate.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int mkdir(MemoryAddress path, short mode) {
-		return fuseOperations.mkdir(path.getUtf8String(0), mode);
+		return delegate.mkdir(path.getUtf8String(0), mode);
 	}
 
 	private int open(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.open(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return delegate.open(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int opendir(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.opendir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return delegate.opendir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int read(MemoryAddress path, MemoryAddress buf, long size, long offset, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
 			var buffer = MemorySegment.ofAddress(buf, size, scope).asByteBuffer();
-			return fuseOperations.read(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
+			return delegate.read(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int readdir(MemoryAddress path, MemoryAddress buf, MemoryAddress filler, long offset, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.readdir(path.getUtf8String(0), new DirFillerImpl(buf, filler, scope), offset, new FileInfoImpl(fi, scope), 0);
+			return delegate.readdir(path.getUtf8String(0), new DirFillerImpl(buf, filler, scope), offset, new FileInfoImpl(fi, scope), 0);
 		}
 	}
 
 	private int readlink(MemoryAddress path, MemoryAddress buf, long len) {
 		try (var scope = MemorySession.openConfined()) {
 			var buffer = MemorySegment.ofAddress(buf, len, scope).asByteBuffer();
-			return fuseOperations.readlink(path.getUtf8String(0), buffer, len);
+			return delegate.readlink(path.getUtf8String(0), buffer, len);
 		}
 	}
 
 	private int release(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.release(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return delegate.release(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int releasedir(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.releasedir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return delegate.releasedir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int rename(MemoryAddress oldpath, MemoryAddress newpath) {
-		return fuseOperations.rename(oldpath.getUtf8String(0), newpath.getUtf8String(0), 0);
+		return delegate.rename(oldpath.getUtf8String(0), newpath.getUtf8String(0), 0);
 	}
 
 	private int rmdir(MemoryAddress path) {
-		return fuseOperations.rmdir(path.getUtf8String(0));
+		return delegate.rmdir(path.getUtf8String(0));
 	}
 
 	private int statfs(MemoryAddress path, MemoryAddress statvfs) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.statfs(path.getUtf8String(0), new StatvfsImpl(statvfs, scope));
+			return delegate.statfs(path.getUtf8String(0), new StatvfsImpl(statvfs, scope));
 		}
 	}
 
 	private int symlink(MemoryAddress linkname, MemoryAddress target) {
-		return fuseOperations.symlink(linkname.getUtf8String(0), target.getUtf8String(0));
+		return delegate.symlink(linkname.getUtf8String(0), target.getUtf8String(0));
 	}
 
 	@VisibleForTesting
 	int truncate(MemoryAddress path, long size) {
-		return fuseOperations.truncate(path.getUtf8String(0), size, null);
+		return delegate.truncate(path.getUtf8String(0), size, null);
 	}
 
 	@VisibleForTesting
 	int ftruncate(MemoryAddress path, long size, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.truncate(path.getUtf8String(0), size, new FileInfoImpl(fi, scope));
+			return delegate.truncate(path.getUtf8String(0), size, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int unlink(MemoryAddress path) {
-		return fuseOperations.unlink(path.getUtf8String(0));
+		return delegate.unlink(path.getUtf8String(0));
 	}
 
 	@VisibleForTesting
@@ -262,13 +262,13 @@ final class FuseImpl extends Fuse {
 				timespec.tv_sec$set(segment, 0);
 				timespec.tv_nsec$set(segment, stat_h.UTIME_NOW());
 				var time = new TimeSpecImpl(segment);
-				return fuseOperations.utimens(path.getUtf8String(0), time, time, null);
+				return delegate.utimens(path.getUtf8String(0), time, time, null);
 			} else {
 				var seq = MemoryLayout.sequenceLayout(2, timespec.$LAYOUT());
 				var segment = MemorySegment.ofAddress(times, seq.byteSize(), scope);
 				var time0 = segment.asSlice(0, timespec.$LAYOUT().byteSize());
 				var time1 = segment.asSlice(timespec.$LAYOUT().byteSize(), timespec.$LAYOUT().byteSize());
-				return fuseOperations.utimens(path.getUtf8String(0), new TimeSpecImpl(time0), new TimeSpecImpl(time1), null);
+				return delegate.utimens(path.getUtf8String(0), new TimeSpecImpl(time0), new TimeSpecImpl(time1), null);
 			}
 		}
 	}
@@ -276,7 +276,7 @@ final class FuseImpl extends Fuse {
 	private int write(MemoryAddress path, MemoryAddress buf, long size, long offset, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
 			var buffer = MemorySegment.ofAddress(buf, size, scope).asByteBuffer();
-			return fuseOperations.write(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
+			return delegate.write(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
 		}
 	}
 

--- a/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/FuseImpl.java
+++ b/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/FuseImpl.java
@@ -23,11 +23,8 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 final class FuseImpl extends Fuse {
 
-	private final MemorySegment segment;
-
 	public FuseImpl(FuseOperations fuseOperations) {
-		super(fuseOperations);
-		this.segment = fuse_operations.allocate(fuseScope);
+		super(fuseOperations, fuse_operations::allocate);
 		fuseOperations.supportedOperations().forEach(this::bind);
 	}
 

--- a/jfuse-tests/src/test/java/org/cryptomator/jfuse/tests/MirrorIT.java
+++ b/jfuse-tests/src/test/java/org/cryptomator/jfuse/tests/MirrorIT.java
@@ -57,7 +57,7 @@ public class MirrorIT {
 	private Fuse fuse;
 
 	@BeforeAll
-	public void setup(@TempDir Path tmpDir) throws IOException, InterruptedException, MountFailedException {
+	public void setup(@TempDir Path tmpDir) throws IOException,  MountFailedException {
 		var builder = Fuse.builder();
 		var libPath = System.getProperty("fuse.lib.path");
 		if (libPath != null && !libPath.isEmpty()) {
@@ -82,7 +82,6 @@ public class MirrorIT {
 		};
 		fuse = builder.build(fs);
 		fuse.mount("mirror-it", mirror, flags.toArray(String[]::new));
-		Thread.sleep(100); // give the file system some time before accessing mounted dir
 	}
 
 	@AfterAll

--- a/jfuse-win/src/main/java/org/cryptomator/jfuse/win/FuseImpl.java
+++ b/jfuse-win/src/main/java/org/cryptomator/jfuse/win/FuseImpl.java
@@ -27,7 +27,6 @@ class FuseImpl extends Fuse {
 
 	public FuseImpl(FuseOperations fuseOperations) {
 		super(fuseOperations, fuse3_operations::allocate);
-		fuseOperations.supportedOperations().forEach(this::bind);
 	}
 
 	@Override
@@ -79,11 +78,8 @@ class FuseImpl extends Fuse {
 		return new FuseArgs(args, mountPoint, isMultiThreaded);
 	}
 
-	/**
-	 * Sets a fuse callback. For supported callbacks, see winfsp/inc/fuse3/fuse_h
-	 * @param operation The fuse operation enum, indicating which operation to set.
-	 */
-	private void bind(FuseOperations.Operation operation) {
+	@Override
+	protected void bind(FuseOperations.Operation operation) {
 		switch (operation) {
 			case INIT -> fuse3_operations.init$set(segment, fuse3_operations.init.allocate(this::init, fuseScope).address());
 			case ACCESS -> fuse3_operations.access$set(segment, MemoryAddress.NULL);

--- a/jfuse-win/src/main/java/org/cryptomator/jfuse/win/FuseImpl.java
+++ b/jfuse-win/src/main/java/org/cryptomator/jfuse/win/FuseImpl.java
@@ -12,34 +12,24 @@ import org.cryptomator.jfuse.win.extr.fuse_h;
 import org.cryptomator.jfuse.win.extr.fuse_timespec;
 import org.jetbrains.annotations.VisibleForTesting;
 
-import java.io.IOException;
 import java.lang.foreign.Addressable;
 import java.lang.foreign.MemoryAddress;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.MemorySession;
 import java.lang.foreign.ValueLayout;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.BasicFileAttributeView;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 class FuseImpl extends Fuse {
 
-	//Used to check, if the mounted fs is actually accessible, see https://github.com/winfsp/winfsp/discussions/440
-	private static final String MOUNT_PROBE = "/jfuse_windows_mount_probe";
-	private final FuseOperations delegate;
-	private final MemorySegment fuseOps;
-
-	private final CountDownLatch mountProbeSucceeded = new CountDownLatch(1);
+	private final MemorySegment segment;
 
 	public FuseImpl(FuseOperations fuseOperations) {
-		this.fuseOps = fuse3_operations.allocate(fuseScope);
-		this.delegate = fuseOperations;
+		super(fuseOperations);
+		this.segment = fuse3_operations.allocate(fuseScope);
 		fuseOperations.supportedOperations().forEach(this::bind);
 	}
 
@@ -51,31 +41,12 @@ class FuseImpl extends Fuse {
 			adjustedMP = Path.of(mountPoint.toString().charAt(0) + ":");
 		}
 		super.mount(progName, adjustedMP, flags);
-		try {
-			waitForMountingToComplete(mountPoint);
-		} catch (InterruptedException e) {
-			Thread.currentThread().interrupt();
-			throw new MountFailedException("Interrupted while waiting for mounting to finish");
-		}
 	}
-
-	@VisibleForTesting
-	void waitForMountingToComplete(Path mountPoint) throws InterruptedException {
-		var probe = Files.getFileAttributeView(mountPoint.resolve(MOUNT_PROBE.substring(1)), BasicFileAttributeView.class);
-		do {
-			try {
-				probe.readAttributes(); // we don't care about the result, we just want to trigger a getattr call
-			} catch (IOException e) {
-				//noop
-			}
-		} while (!mountProbeSucceeded.await(333, TimeUnit.MILLISECONDS));
-	}
-
 
 	@Override
 	protected FuseMount mount(List<String> args) throws MountFailedException {
 		var fuseArgs = parseArgs(args);
-		var fuse = fuse_h.fuse3_new(fuseArgs.args(), fuseOps, fuseOps.byteSize(), MemoryAddress.NULL);
+		var fuse = fuse_h.fuse3_new(fuseArgs.args(), segment, segment.byteSize(), MemoryAddress.NULL);
 		if (MemoryAddress.NULL.equals(fuse)) {
 			throw new MountFailedException("fuse_new failed");
 		}
@@ -117,32 +88,32 @@ class FuseImpl extends Fuse {
 	 */
 	private void bind(FuseOperations.Operation operation) {
 		switch (operation) {
-			case INIT -> fuse3_operations.init$set(fuseOps, fuse3_operations.init.allocate(this::init, fuseScope).address());
-			case ACCESS -> fuse3_operations.access$set(fuseOps, MemoryAddress.NULL);
-			case CHMOD -> fuse3_operations.chmod$set(fuseOps, fuse3_operations.chmod.allocate(this::chmod, fuseScope).address());
-			case CHOWN -> fuse3_operations.chown$set(fuseOps, fuse3_operations.chown.allocate(this::chown, fuseScope).address());
-			case CREATE -> fuse3_operations.create$set(fuseOps, fuse3_operations.create.allocate(this::create, fuseScope).address());
-			case DESTROY -> fuse3_operations.destroy$set(fuseOps, fuse3_operations.destroy.allocate(this::destroy, fuseScope).address());
-			case FLUSH -> fuse3_operations.flush$set(fuseOps, fuse3_operations.flush.allocate(this::flush, fuseScope).address());
-			case FSYNC -> fuse3_operations.fsync$set(fuseOps, fuse3_operations.fsync.allocate(this::fsync, fuseScope).address());
-			case FSYNCDIR -> fuse3_operations.fsyncdir$set(fuseOps, fuse3_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
-			case GET_ATTR -> fuse3_operations.getattr$set(fuseOps, fuse3_operations.getattr.allocate(this::getattr, fuseScope).address());
-			case MKDIR -> fuse3_operations.mkdir$set(fuseOps, fuse3_operations.mkdir.allocate(this::mkdir, fuseScope).address());
-			case OPEN -> fuse3_operations.open$set(fuseOps, fuse3_operations.open.allocate(this::open, fuseScope).address());
-			case OPEN_DIR -> fuse3_operations.opendir$set(fuseOps, fuse3_operations.opendir.allocate(this::opendir, fuseScope).address());
-			case READ -> fuse3_operations.read$set(fuseOps, fuse3_operations.read.allocate(this::read, fuseScope).address());
-			case READ_DIR -> fuse3_operations.readdir$set(fuseOps, fuse3_operations.readdir.allocate(this::readdir, fuseScope).address());
-			case READLINK -> fuse3_operations.readlink$set(fuseOps, fuse3_operations.readlink.allocate(this::readlink, fuseScope).address());
-			case RELEASE -> fuse3_operations.release$set(fuseOps, fuse3_operations.release.allocate(this::release, fuseScope).address());
-			case RELEASE_DIR -> fuse3_operations.releasedir$set(fuseOps, fuse3_operations.releasedir.allocate(this::releasedir, fuseScope).address());
-			case RENAME -> fuse3_operations.rename$set(fuseOps, fuse3_operations.rename.allocate(this::rename, fuseScope).address());
-			case RMDIR -> fuse3_operations.rmdir$set(fuseOps, fuse3_operations.rmdir.allocate(this::rmdir, fuseScope).address());
-			case STATFS -> fuse3_operations.statfs$set(fuseOps, fuse3_operations.statfs.allocate(this::statfs, fuseScope).address());
-			case SYMLINK -> fuse3_operations.symlink$set(fuseOps, fuse3_operations.symlink.allocate(this::symlink, fuseScope).address());
-			case TRUNCATE -> fuse3_operations.truncate$set(fuseOps, fuse3_operations.truncate.allocate(this::truncate, fuseScope).address());
-			case UNLINK -> fuse3_operations.unlink$set(fuseOps, fuse3_operations.unlink.allocate(this::unlink, fuseScope).address());
-			case UTIMENS -> fuse3_operations.utimens$set(fuseOps, fuse3_operations.utimens.allocate(this::utimens, fuseScope).address());
-			case WRITE -> fuse3_operations.write$set(fuseOps, fuse3_operations.write.allocate(this::write, fuseScope).address());
+			case INIT -> fuse3_operations.init$set(segment, fuse3_operations.init.allocate(this::init, fuseScope).address());
+			case ACCESS -> fuse3_operations.access$set(segment, MemoryAddress.NULL);
+			case CHMOD -> fuse3_operations.chmod$set(segment, fuse3_operations.chmod.allocate(this::chmod, fuseScope).address());
+			case CHOWN -> fuse3_operations.chown$set(segment, fuse3_operations.chown.allocate(this::chown, fuseScope).address());
+			case CREATE -> fuse3_operations.create$set(segment, fuse3_operations.create.allocate(this::create, fuseScope).address());
+			case DESTROY -> fuse3_operations.destroy$set(segment, fuse3_operations.destroy.allocate(this::destroy, fuseScope).address());
+			case FLUSH -> fuse3_operations.flush$set(segment, fuse3_operations.flush.allocate(this::flush, fuseScope).address());
+			case FSYNC -> fuse3_operations.fsync$set(segment, fuse3_operations.fsync.allocate(this::fsync, fuseScope).address());
+			case FSYNCDIR -> fuse3_operations.fsyncdir$set(segment, fuse3_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
+			case GET_ATTR -> fuse3_operations.getattr$set(segment, fuse3_operations.getattr.allocate(this::getattr, fuseScope).address());
+			case MKDIR -> fuse3_operations.mkdir$set(segment, fuse3_operations.mkdir.allocate(this::mkdir, fuseScope).address());
+			case OPEN -> fuse3_operations.open$set(segment, fuse3_operations.open.allocate(this::open, fuseScope).address());
+			case OPEN_DIR -> fuse3_operations.opendir$set(segment, fuse3_operations.opendir.allocate(this::opendir, fuseScope).address());
+			case READ -> fuse3_operations.read$set(segment, fuse3_operations.read.allocate(this::read, fuseScope).address());
+			case READ_DIR -> fuse3_operations.readdir$set(segment, fuse3_operations.readdir.allocate(this::readdir, fuseScope).address());
+			case READLINK -> fuse3_operations.readlink$set(segment, fuse3_operations.readlink.allocate(this::readlink, fuseScope).address());
+			case RELEASE -> fuse3_operations.release$set(segment, fuse3_operations.release.allocate(this::release, fuseScope).address());
+			case RELEASE_DIR -> fuse3_operations.releasedir$set(segment, fuse3_operations.releasedir.allocate(this::releasedir, fuseScope).address());
+			case RENAME -> fuse3_operations.rename$set(segment, fuse3_operations.rename.allocate(this::rename, fuseScope).address());
+			case RMDIR -> fuse3_operations.rmdir$set(segment, fuse3_operations.rmdir.allocate(this::rmdir, fuseScope).address());
+			case STATFS -> fuse3_operations.statfs$set(segment, fuse3_operations.statfs.allocate(this::statfs, fuseScope).address());
+			case SYMLINK -> fuse3_operations.symlink$set(segment, fuse3_operations.symlink.allocate(this::symlink, fuseScope).address());
+			case TRUNCATE -> fuse3_operations.truncate$set(segment, fuse3_operations.truncate.allocate(this::truncate, fuseScope).address());
+			case UNLINK -> fuse3_operations.unlink$set(segment, fuse3_operations.unlink.allocate(this::unlink, fuseScope).address());
+			case UTIMENS -> fuse3_operations.utimens$set(segment, fuse3_operations.utimens.allocate(this::utimens, fuseScope).address());
+			case WRITE -> fuse3_operations.write$set(segment, fuse3_operations.write.allocate(this::write, fuseScope).address());
 		}
 	}
 
@@ -152,141 +123,137 @@ class FuseImpl extends Fuse {
 			var connInfo = new FuseConnInfoImpl(conn, scope);
 			connInfo.setWant(connInfo.want() | FuseConnInfo.FUSE_CAP_READDIRPLUS);
 			var config = new org.cryptomator.jfuse.win.FuseConfigImpl(cfg, scope);
-			delegate.init(connInfo, config);
+			fuseOperations.init(connInfo, config);
 		}
 		return MemoryAddress.NULL;
 	}
 
 	private int chmod(MemoryAddress path, int mode, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.chmod(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
+			return fuseOperations.chmod(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	@VisibleForTesting
 	int chown(MemoryAddress path, int uid, int gid, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.chown(path.getUtf8String(0), uid, gid, new FileInfoImpl(fi, scope));
+			return fuseOperations.chown(path.getUtf8String(0), uid, gid, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int create(MemoryAddress path, int mode, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.create(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
+			return fuseOperations.create(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private void destroy(MemoryAddress addr) {
-		delegate.destroy();
+		fuseOperations.destroy();
 	}
 
 	@VisibleForTesting
 	int flush(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.flush(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return fuseOperations.flush(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	@VisibleForTesting
 	int fsync(MemoryAddress path, int datasync, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.fsync(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
+			return fuseOperations.fsync(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	@VisibleForTesting
 	int fsyncdir(MemoryAddress path, int datasync, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.fsyncdir(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
+			return fuseOperations.fsyncdir(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	@VisibleForTesting
 	int getattr(MemoryAddress path, MemoryAddress stat, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			var pathObj = path.getUtf8String(0);
-			if(mountProbeSucceeded.getCount() > 0 && pathObj.equals(MOUNT_PROBE) ) {
-				mountProbeSucceeded.countDown();
-			}
-			return delegate.getattr(pathObj, new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
+			return this.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int mkdir(MemoryAddress path, int mode) {
-		return delegate.mkdir(path.getUtf8String(0), mode);
+		return fuseOperations.mkdir(path.getUtf8String(0), mode);
 	}
 
 	private int open(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.open(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return fuseOperations.open(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int opendir(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.opendir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return fuseOperations.opendir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int read(MemoryAddress path, MemoryAddress buf, long size, long offset, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
 			var buffer = MemorySegment.ofAddress(buf, size, scope).asByteBuffer();
-			return delegate.read(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
+			return fuseOperations.read(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int readdir(MemoryAddress path, MemoryAddress buf, MemoryAddress filler, long offset, MemoryAddress fi, int flags) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.readdir(path.getUtf8String(0), new DirFillerImpl(buf, filler, scope), offset, new FileInfoImpl(fi, scope), flags);
+			return fuseOperations.readdir(path.getUtf8String(0), new DirFillerImpl(buf, filler, scope), offset, new FileInfoImpl(fi, scope), flags);
 		}
 	}
 
 	private int readlink(MemoryAddress path, MemoryAddress buf, long len) {
 		try (var scope = MemorySession.openConfined()) {
 			var buffer = MemorySegment.ofAddress(buf, len, scope).asByteBuffer();
-			return delegate.readlink(path.getUtf8String(0), buffer, len);
+			return fuseOperations.readlink(path.getUtf8String(0), buffer, len);
 		}
 	}
 
 	private int release(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.release(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return fuseOperations.release(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int releasedir(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.releasedir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return fuseOperations.releasedir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int rename(MemoryAddress oldpath, MemoryAddress newpath, int flags) {
-		return delegate.rename(oldpath.getUtf8String(0), newpath.getUtf8String(0), flags);
+		return fuseOperations.rename(oldpath.getUtf8String(0), newpath.getUtf8String(0), flags);
 	}
 
 	private int rmdir(MemoryAddress path) {
-		return delegate.rmdir(path.getUtf8String(0));
+		return fuseOperations.rmdir(path.getUtf8String(0));
 	}
 
 	private int statfs(MemoryAddress path, MemoryAddress statvfs) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.statfs(path.getUtf8String(0), new StatvfsImpl(statvfs, scope));
+			return fuseOperations.statfs(path.getUtf8String(0), new StatvfsImpl(statvfs, scope));
 		}
 	}
 
 	private int symlink(MemoryAddress linkname, MemoryAddress target) {
-		return delegate.symlink(linkname.getUtf8String(0), target.getUtf8String(0));
+		return fuseOperations.symlink(linkname.getUtf8String(0), target.getUtf8String(0));
 	}
 
 	@VisibleForTesting
 	int truncate(MemoryAddress path, long size, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return delegate.truncate(path.getUtf8String(0), size, new FileInfoImpl(fi, scope));
+			return fuseOperations.truncate(path.getUtf8String(0), size, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int unlink(MemoryAddress path) {
-		return delegate.unlink(path.getUtf8String(0));
+		return fuseOperations.unlink(path.getUtf8String(0));
 	}
 
 	@VisibleForTesting
@@ -298,14 +265,14 @@ class FuseImpl extends Fuse {
 			var segment = MemorySegment.ofAddress(times, seq.byteSize(), scope);
 			var time0 = segment.asSlice(0, fuse_timespec.$LAYOUT().byteSize());
 			var time1 = segment.asSlice(fuse_timespec.$LAYOUT().byteSize(), fuse_timespec.$LAYOUT().byteSize());
-			return delegate.utimens(path.getUtf8String(0), new TimeSpecImpl(time0), new TimeSpecImpl(time1), new FileInfoImpl(fi, scope));
+			return fuseOperations.utimens(path.getUtf8String(0), new TimeSpecImpl(time0), new TimeSpecImpl(time1), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int write(MemoryAddress path, MemoryAddress buf, long size, long offset, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
 			var buffer = MemorySegment.ofAddress(buf, size, scope).asByteBuffer();
-			return delegate.write(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
+			return fuseOperations.write(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
 		}
 	}
 

--- a/jfuse-win/src/main/java/org/cryptomator/jfuse/win/FuseImpl.java
+++ b/jfuse-win/src/main/java/org/cryptomator/jfuse/win/FuseImpl.java
@@ -42,7 +42,7 @@ class FuseImpl extends Fuse {
 	@Override
 	protected FuseMount mount(List<String> args) throws MountFailedException {
 		var fuseArgs = parseArgs(args);
-		var fuse = fuse_h.fuse3_new(fuseArgs.args(), fuseOperationsStruct, fuseOperationsStruct.byteSize(), MemoryAddress.NULL);
+		var fuse = fuse_h.fuse3_new(fuseArgs.args(), fuseOps, fuseOps.byteSize(), MemoryAddress.NULL);
 		if (MemoryAddress.NULL.equals(fuse)) {
 			throw new MountFailedException("fuse_new failed");
 		}
@@ -81,32 +81,32 @@ class FuseImpl extends Fuse {
 	@Override
 	protected void bind(FuseOperations.Operation operation) {
 		switch (operation) {
-			case INIT -> fuse3_operations.init$set(fuseOperationsStruct, fuse3_operations.init.allocate(this::init, fuseScope).address());
-			case ACCESS -> fuse3_operations.access$set(fuseOperationsStruct, MemoryAddress.NULL);
-			case CHMOD -> fuse3_operations.chmod$set(fuseOperationsStruct, fuse3_operations.chmod.allocate(this::chmod, fuseScope).address());
-			case CHOWN -> fuse3_operations.chown$set(fuseOperationsStruct, fuse3_operations.chown.allocate(this::chown, fuseScope).address());
-			case CREATE -> fuse3_operations.create$set(fuseOperationsStruct, fuse3_operations.create.allocate(this::create, fuseScope).address());
-			case DESTROY -> fuse3_operations.destroy$set(fuseOperationsStruct, fuse3_operations.destroy.allocate(this::destroy, fuseScope).address());
-			case FLUSH -> fuse3_operations.flush$set(fuseOperationsStruct, fuse3_operations.flush.allocate(this::flush, fuseScope).address());
-			case FSYNC -> fuse3_operations.fsync$set(fuseOperationsStruct, fuse3_operations.fsync.allocate(this::fsync, fuseScope).address());
-			case FSYNCDIR -> fuse3_operations.fsyncdir$set(fuseOperationsStruct, fuse3_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
-			case GET_ATTR -> fuse3_operations.getattr$set(fuseOperationsStruct, fuse3_operations.getattr.allocate(this::getattr, fuseScope).address());
-			case MKDIR -> fuse3_operations.mkdir$set(fuseOperationsStruct, fuse3_operations.mkdir.allocate(this::mkdir, fuseScope).address());
-			case OPEN -> fuse3_operations.open$set(fuseOperationsStruct, fuse3_operations.open.allocate(this::open, fuseScope).address());
-			case OPEN_DIR -> fuse3_operations.opendir$set(fuseOperationsStruct, fuse3_operations.opendir.allocate(this::opendir, fuseScope).address());
-			case READ -> fuse3_operations.read$set(fuseOperationsStruct, fuse3_operations.read.allocate(this::read, fuseScope).address());
-			case READ_DIR -> fuse3_operations.readdir$set(fuseOperationsStruct, fuse3_operations.readdir.allocate(this::readdir, fuseScope).address());
-			case READLINK -> fuse3_operations.readlink$set(fuseOperationsStruct, fuse3_operations.readlink.allocate(this::readlink, fuseScope).address());
-			case RELEASE -> fuse3_operations.release$set(fuseOperationsStruct, fuse3_operations.release.allocate(this::release, fuseScope).address());
-			case RELEASE_DIR -> fuse3_operations.releasedir$set(fuseOperationsStruct, fuse3_operations.releasedir.allocate(this::releasedir, fuseScope).address());
-			case RENAME -> fuse3_operations.rename$set(fuseOperationsStruct, fuse3_operations.rename.allocate(this::rename, fuseScope).address());
-			case RMDIR -> fuse3_operations.rmdir$set(fuseOperationsStruct, fuse3_operations.rmdir.allocate(this::rmdir, fuseScope).address());
-			case STATFS -> fuse3_operations.statfs$set(fuseOperationsStruct, fuse3_operations.statfs.allocate(this::statfs, fuseScope).address());
-			case SYMLINK -> fuse3_operations.symlink$set(fuseOperationsStruct, fuse3_operations.symlink.allocate(this::symlink, fuseScope).address());
-			case TRUNCATE -> fuse3_operations.truncate$set(fuseOperationsStruct, fuse3_operations.truncate.allocate(this::truncate, fuseScope).address());
-			case UNLINK -> fuse3_operations.unlink$set(fuseOperationsStruct, fuse3_operations.unlink.allocate(this::unlink, fuseScope).address());
-			case UTIMENS -> fuse3_operations.utimens$set(fuseOperationsStruct, fuse3_operations.utimens.allocate(this::utimens, fuseScope).address());
-			case WRITE -> fuse3_operations.write$set(fuseOperationsStruct, fuse3_operations.write.allocate(this::write, fuseScope).address());
+			case INIT -> fuse3_operations.init$set(fuseOps, fuse3_operations.init.allocate(this::init, fuseScope).address());
+			case ACCESS -> fuse3_operations.access$set(fuseOps, MemoryAddress.NULL);
+			case CHMOD -> fuse3_operations.chmod$set(fuseOps, fuse3_operations.chmod.allocate(this::chmod, fuseScope).address());
+			case CHOWN -> fuse3_operations.chown$set(fuseOps, fuse3_operations.chown.allocate(this::chown, fuseScope).address());
+			case CREATE -> fuse3_operations.create$set(fuseOps, fuse3_operations.create.allocate(this::create, fuseScope).address());
+			case DESTROY -> fuse3_operations.destroy$set(fuseOps, fuse3_operations.destroy.allocate(this::destroy, fuseScope).address());
+			case FLUSH -> fuse3_operations.flush$set(fuseOps, fuse3_operations.flush.allocate(this::flush, fuseScope).address());
+			case FSYNC -> fuse3_operations.fsync$set(fuseOps, fuse3_operations.fsync.allocate(this::fsync, fuseScope).address());
+			case FSYNCDIR -> fuse3_operations.fsyncdir$set(fuseOps, fuse3_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
+			case GET_ATTR -> fuse3_operations.getattr$set(fuseOps, fuse3_operations.getattr.allocate(this::getattr, fuseScope).address());
+			case MKDIR -> fuse3_operations.mkdir$set(fuseOps, fuse3_operations.mkdir.allocate(this::mkdir, fuseScope).address());
+			case OPEN -> fuse3_operations.open$set(fuseOps, fuse3_operations.open.allocate(this::open, fuseScope).address());
+			case OPEN_DIR -> fuse3_operations.opendir$set(fuseOps, fuse3_operations.opendir.allocate(this::opendir, fuseScope).address());
+			case READ -> fuse3_operations.read$set(fuseOps, fuse3_operations.read.allocate(this::read, fuseScope).address());
+			case READ_DIR -> fuse3_operations.readdir$set(fuseOps, fuse3_operations.readdir.allocate(this::readdir, fuseScope).address());
+			case READLINK -> fuse3_operations.readlink$set(fuseOps, fuse3_operations.readlink.allocate(this::readlink, fuseScope).address());
+			case RELEASE -> fuse3_operations.release$set(fuseOps, fuse3_operations.release.allocate(this::release, fuseScope).address());
+			case RELEASE_DIR -> fuse3_operations.releasedir$set(fuseOps, fuse3_operations.releasedir.allocate(this::releasedir, fuseScope).address());
+			case RENAME -> fuse3_operations.rename$set(fuseOps, fuse3_operations.rename.allocate(this::rename, fuseScope).address());
+			case RMDIR -> fuse3_operations.rmdir$set(fuseOps, fuse3_operations.rmdir.allocate(this::rmdir, fuseScope).address());
+			case STATFS -> fuse3_operations.statfs$set(fuseOps, fuse3_operations.statfs.allocate(this::statfs, fuseScope).address());
+			case SYMLINK -> fuse3_operations.symlink$set(fuseOps, fuse3_operations.symlink.allocate(this::symlink, fuseScope).address());
+			case TRUNCATE -> fuse3_operations.truncate$set(fuseOps, fuse3_operations.truncate.allocate(this::truncate, fuseScope).address());
+			case UNLINK -> fuse3_operations.unlink$set(fuseOps, fuse3_operations.unlink.allocate(this::unlink, fuseScope).address());
+			case UTIMENS -> fuse3_operations.utimens$set(fuseOps, fuse3_operations.utimens.allocate(this::utimens, fuseScope).address());
+			case WRITE -> fuse3_operations.write$set(fuseOps, fuse3_operations.write.allocate(this::write, fuseScope).address());
 		}
 	}
 
@@ -116,137 +116,137 @@ class FuseImpl extends Fuse {
 			var connInfo = new FuseConnInfoImpl(conn, scope);
 			connInfo.setWant(connInfo.want() | FuseConnInfo.FUSE_CAP_READDIRPLUS);
 			var config = new org.cryptomator.jfuse.win.FuseConfigImpl(cfg, scope);
-			fuseOperations.init(connInfo, config);
+			delegate.init(connInfo, config);
 		}
 		return MemoryAddress.NULL;
 	}
 
 	private int chmod(MemoryAddress path, int mode, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.chmod(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
+			return delegate.chmod(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	@VisibleForTesting
 	int chown(MemoryAddress path, int uid, int gid, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.chown(path.getUtf8String(0), uid, gid, new FileInfoImpl(fi, scope));
+			return delegate.chown(path.getUtf8String(0), uid, gid, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int create(MemoryAddress path, int mode, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.create(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
+			return delegate.create(path.getUtf8String(0), mode, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private void destroy(MemoryAddress addr) {
-		fuseOperations.destroy();
+		delegate.destroy();
 	}
 
 	@VisibleForTesting
 	int flush(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.flush(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return delegate.flush(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	@VisibleForTesting
 	int fsync(MemoryAddress path, int datasync, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.fsync(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
+			return delegate.fsync(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	@VisibleForTesting
 	int fsyncdir(MemoryAddress path, int datasync, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.fsyncdir(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
+			return delegate.fsyncdir(path.getUtf8String(0), datasync, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	@VisibleForTesting
 	int getattr(MemoryAddress path, MemoryAddress stat, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
+			return delegate.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int mkdir(MemoryAddress path, int mode) {
-		return fuseOperations.mkdir(path.getUtf8String(0), mode);
+		return delegate.mkdir(path.getUtf8String(0), mode);
 	}
 
 	private int open(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.open(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return delegate.open(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int opendir(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.opendir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return delegate.opendir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int read(MemoryAddress path, MemoryAddress buf, long size, long offset, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
 			var buffer = MemorySegment.ofAddress(buf, size, scope).asByteBuffer();
-			return fuseOperations.read(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
+			return delegate.read(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int readdir(MemoryAddress path, MemoryAddress buf, MemoryAddress filler, long offset, MemoryAddress fi, int flags) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.readdir(path.getUtf8String(0), new DirFillerImpl(buf, filler, scope), offset, new FileInfoImpl(fi, scope), flags);
+			return delegate.readdir(path.getUtf8String(0), new DirFillerImpl(buf, filler, scope), offset, new FileInfoImpl(fi, scope), flags);
 		}
 	}
 
 	private int readlink(MemoryAddress path, MemoryAddress buf, long len) {
 		try (var scope = MemorySession.openConfined()) {
 			var buffer = MemorySegment.ofAddress(buf, len, scope).asByteBuffer();
-			return fuseOperations.readlink(path.getUtf8String(0), buffer, len);
+			return delegate.readlink(path.getUtf8String(0), buffer, len);
 		}
 	}
 
 	private int release(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.release(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return delegate.release(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int releasedir(MemoryAddress path, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.releasedir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
+			return delegate.releasedir(path.getUtf8String(0), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int rename(MemoryAddress oldpath, MemoryAddress newpath, int flags) {
-		return fuseOperations.rename(oldpath.getUtf8String(0), newpath.getUtf8String(0), flags);
+		return delegate.rename(oldpath.getUtf8String(0), newpath.getUtf8String(0), flags);
 	}
 
 	private int rmdir(MemoryAddress path) {
-		return fuseOperations.rmdir(path.getUtf8String(0));
+		return delegate.rmdir(path.getUtf8String(0));
 	}
 
 	private int statfs(MemoryAddress path, MemoryAddress statvfs) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.statfs(path.getUtf8String(0), new StatvfsImpl(statvfs, scope));
+			return delegate.statfs(path.getUtf8String(0), new StatvfsImpl(statvfs, scope));
 		}
 	}
 
 	private int symlink(MemoryAddress linkname, MemoryAddress target) {
-		return fuseOperations.symlink(linkname.getUtf8String(0), target.getUtf8String(0));
+		return delegate.symlink(linkname.getUtf8String(0), target.getUtf8String(0));
 	}
 
 	@VisibleForTesting
 	int truncate(MemoryAddress path, long size, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return fuseOperations.truncate(path.getUtf8String(0), size, new FileInfoImpl(fi, scope));
+			return delegate.truncate(path.getUtf8String(0), size, new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int unlink(MemoryAddress path) {
-		return fuseOperations.unlink(path.getUtf8String(0));
+		return delegate.unlink(path.getUtf8String(0));
 	}
 
 	@VisibleForTesting
@@ -258,14 +258,14 @@ class FuseImpl extends Fuse {
 			var segment = MemorySegment.ofAddress(times, seq.byteSize(), scope);
 			var time0 = segment.asSlice(0, fuse_timespec.$LAYOUT().byteSize());
 			var time1 = segment.asSlice(fuse_timespec.$LAYOUT().byteSize(), fuse_timespec.$LAYOUT().byteSize());
-			return fuseOperations.utimens(path.getUtf8String(0), new TimeSpecImpl(time0), new TimeSpecImpl(time1), new FileInfoImpl(fi, scope));
+			return delegate.utimens(path.getUtf8String(0), new TimeSpecImpl(time0), new TimeSpecImpl(time1), new FileInfoImpl(fi, scope));
 		}
 	}
 
 	private int write(MemoryAddress path, MemoryAddress buf, long size, long offset, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
 			var buffer = MemorySegment.ofAddress(buf, size, scope).asByteBuffer();
-			return fuseOperations.write(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
+			return delegate.write(path.getUtf8String(0), buffer, size, offset, new FileInfoImpl(fi, scope));
 		}
 	}
 

--- a/jfuse-win/src/main/java/org/cryptomator/jfuse/win/FuseImpl.java
+++ b/jfuse-win/src/main/java/org/cryptomator/jfuse/win/FuseImpl.java
@@ -168,7 +168,7 @@ class FuseImpl extends Fuse {
 	@VisibleForTesting
 	int getattr(MemoryAddress path, MemoryAddress stat, MemoryAddress fi) {
 		try (var scope = MemorySession.openConfined()) {
-			return this.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
+			return fuseOperations.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
 		}
 	}
 

--- a/jfuse-win/src/main/java/org/cryptomator/jfuse/win/FuseImpl.java
+++ b/jfuse-win/src/main/java/org/cryptomator/jfuse/win/FuseImpl.java
@@ -42,7 +42,7 @@ class FuseImpl extends Fuse {
 	@Override
 	protected FuseMount mount(List<String> args) throws MountFailedException {
 		var fuseArgs = parseArgs(args);
-		var fuse = fuse_h.fuse3_new(fuseArgs.args(), segment, segment.byteSize(), MemoryAddress.NULL);
+		var fuse = fuse_h.fuse3_new(fuseArgs.args(), fuseOperationsStruct, fuseOperationsStruct.byteSize(), MemoryAddress.NULL);
 		if (MemoryAddress.NULL.equals(fuse)) {
 			throw new MountFailedException("fuse_new failed");
 		}
@@ -81,32 +81,32 @@ class FuseImpl extends Fuse {
 	@Override
 	protected void bind(FuseOperations.Operation operation) {
 		switch (operation) {
-			case INIT -> fuse3_operations.init$set(segment, fuse3_operations.init.allocate(this::init, fuseScope).address());
-			case ACCESS -> fuse3_operations.access$set(segment, MemoryAddress.NULL);
-			case CHMOD -> fuse3_operations.chmod$set(segment, fuse3_operations.chmod.allocate(this::chmod, fuseScope).address());
-			case CHOWN -> fuse3_operations.chown$set(segment, fuse3_operations.chown.allocate(this::chown, fuseScope).address());
-			case CREATE -> fuse3_operations.create$set(segment, fuse3_operations.create.allocate(this::create, fuseScope).address());
-			case DESTROY -> fuse3_operations.destroy$set(segment, fuse3_operations.destroy.allocate(this::destroy, fuseScope).address());
-			case FLUSH -> fuse3_operations.flush$set(segment, fuse3_operations.flush.allocate(this::flush, fuseScope).address());
-			case FSYNC -> fuse3_operations.fsync$set(segment, fuse3_operations.fsync.allocate(this::fsync, fuseScope).address());
-			case FSYNCDIR -> fuse3_operations.fsyncdir$set(segment, fuse3_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
-			case GET_ATTR -> fuse3_operations.getattr$set(segment, fuse3_operations.getattr.allocate(this::getattr, fuseScope).address());
-			case MKDIR -> fuse3_operations.mkdir$set(segment, fuse3_operations.mkdir.allocate(this::mkdir, fuseScope).address());
-			case OPEN -> fuse3_operations.open$set(segment, fuse3_operations.open.allocate(this::open, fuseScope).address());
-			case OPEN_DIR -> fuse3_operations.opendir$set(segment, fuse3_operations.opendir.allocate(this::opendir, fuseScope).address());
-			case READ -> fuse3_operations.read$set(segment, fuse3_operations.read.allocate(this::read, fuseScope).address());
-			case READ_DIR -> fuse3_operations.readdir$set(segment, fuse3_operations.readdir.allocate(this::readdir, fuseScope).address());
-			case READLINK -> fuse3_operations.readlink$set(segment, fuse3_operations.readlink.allocate(this::readlink, fuseScope).address());
-			case RELEASE -> fuse3_operations.release$set(segment, fuse3_operations.release.allocate(this::release, fuseScope).address());
-			case RELEASE_DIR -> fuse3_operations.releasedir$set(segment, fuse3_operations.releasedir.allocate(this::releasedir, fuseScope).address());
-			case RENAME -> fuse3_operations.rename$set(segment, fuse3_operations.rename.allocate(this::rename, fuseScope).address());
-			case RMDIR -> fuse3_operations.rmdir$set(segment, fuse3_operations.rmdir.allocate(this::rmdir, fuseScope).address());
-			case STATFS -> fuse3_operations.statfs$set(segment, fuse3_operations.statfs.allocate(this::statfs, fuseScope).address());
-			case SYMLINK -> fuse3_operations.symlink$set(segment, fuse3_operations.symlink.allocate(this::symlink, fuseScope).address());
-			case TRUNCATE -> fuse3_operations.truncate$set(segment, fuse3_operations.truncate.allocate(this::truncate, fuseScope).address());
-			case UNLINK -> fuse3_operations.unlink$set(segment, fuse3_operations.unlink.allocate(this::unlink, fuseScope).address());
-			case UTIMENS -> fuse3_operations.utimens$set(segment, fuse3_operations.utimens.allocate(this::utimens, fuseScope).address());
-			case WRITE -> fuse3_operations.write$set(segment, fuse3_operations.write.allocate(this::write, fuseScope).address());
+			case INIT -> fuse3_operations.init$set(fuseOperationsStruct, fuse3_operations.init.allocate(this::init, fuseScope).address());
+			case ACCESS -> fuse3_operations.access$set(fuseOperationsStruct, MemoryAddress.NULL);
+			case CHMOD -> fuse3_operations.chmod$set(fuseOperationsStruct, fuse3_operations.chmod.allocate(this::chmod, fuseScope).address());
+			case CHOWN -> fuse3_operations.chown$set(fuseOperationsStruct, fuse3_operations.chown.allocate(this::chown, fuseScope).address());
+			case CREATE -> fuse3_operations.create$set(fuseOperationsStruct, fuse3_operations.create.allocate(this::create, fuseScope).address());
+			case DESTROY -> fuse3_operations.destroy$set(fuseOperationsStruct, fuse3_operations.destroy.allocate(this::destroy, fuseScope).address());
+			case FLUSH -> fuse3_operations.flush$set(fuseOperationsStruct, fuse3_operations.flush.allocate(this::flush, fuseScope).address());
+			case FSYNC -> fuse3_operations.fsync$set(fuseOperationsStruct, fuse3_operations.fsync.allocate(this::fsync, fuseScope).address());
+			case FSYNCDIR -> fuse3_operations.fsyncdir$set(fuseOperationsStruct, fuse3_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
+			case GET_ATTR -> fuse3_operations.getattr$set(fuseOperationsStruct, fuse3_operations.getattr.allocate(this::getattr, fuseScope).address());
+			case MKDIR -> fuse3_operations.mkdir$set(fuseOperationsStruct, fuse3_operations.mkdir.allocate(this::mkdir, fuseScope).address());
+			case OPEN -> fuse3_operations.open$set(fuseOperationsStruct, fuse3_operations.open.allocate(this::open, fuseScope).address());
+			case OPEN_DIR -> fuse3_operations.opendir$set(fuseOperationsStruct, fuse3_operations.opendir.allocate(this::opendir, fuseScope).address());
+			case READ -> fuse3_operations.read$set(fuseOperationsStruct, fuse3_operations.read.allocate(this::read, fuseScope).address());
+			case READ_DIR -> fuse3_operations.readdir$set(fuseOperationsStruct, fuse3_operations.readdir.allocate(this::readdir, fuseScope).address());
+			case READLINK -> fuse3_operations.readlink$set(fuseOperationsStruct, fuse3_operations.readlink.allocate(this::readlink, fuseScope).address());
+			case RELEASE -> fuse3_operations.release$set(fuseOperationsStruct, fuse3_operations.release.allocate(this::release, fuseScope).address());
+			case RELEASE_DIR -> fuse3_operations.releasedir$set(fuseOperationsStruct, fuse3_operations.releasedir.allocate(this::releasedir, fuseScope).address());
+			case RENAME -> fuse3_operations.rename$set(fuseOperationsStruct, fuse3_operations.rename.allocate(this::rename, fuseScope).address());
+			case RMDIR -> fuse3_operations.rmdir$set(fuseOperationsStruct, fuse3_operations.rmdir.allocate(this::rmdir, fuseScope).address());
+			case STATFS -> fuse3_operations.statfs$set(fuseOperationsStruct, fuse3_operations.statfs.allocate(this::statfs, fuseScope).address());
+			case SYMLINK -> fuse3_operations.symlink$set(fuseOperationsStruct, fuse3_operations.symlink.allocate(this::symlink, fuseScope).address());
+			case TRUNCATE -> fuse3_operations.truncate$set(fuseOperationsStruct, fuse3_operations.truncate.allocate(this::truncate, fuseScope).address());
+			case UNLINK -> fuse3_operations.unlink$set(fuseOperationsStruct, fuse3_operations.unlink.allocate(this::unlink, fuseScope).address());
+			case UTIMENS -> fuse3_operations.utimens$set(fuseOperationsStruct, fuse3_operations.utimens.allocate(this::utimens, fuseScope).address());
+			case WRITE -> fuse3_operations.write$set(fuseOperationsStruct, fuse3_operations.write.allocate(this::write, fuseScope).address());
 		}
 	}
 

--- a/jfuse-win/src/main/java/org/cryptomator/jfuse/win/FuseImpl.java
+++ b/jfuse-win/src/main/java/org/cryptomator/jfuse/win/FuseImpl.java
@@ -25,11 +25,8 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 class FuseImpl extends Fuse {
 
-	private final MemorySegment segment;
-
 	public FuseImpl(FuseOperations fuseOperations) {
-		super(fuseOperations);
-		this.segment = fuse3_operations.allocate(fuseScope);
+		super(fuseOperations, fuse3_operations::allocate);
 		fuseOperations.supportedOperations().forEach(this::bind);
 	}
 


### PR DESCRIPTION
This moves some code from `jfuse-xyz` to `jfuse-api`, mainly to make the mount probe mechanism available to all implementations without introducing many duplications.