### PR TITLE
use fuse-t on macOS 12 during CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
 
   mac:
     name: Test jfuse-mac
-    runs-on: macos-10.15
+    runs-on: macos-12
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - uses: actions/checkout@v3
@@ -39,9 +39,12 @@ jobs:
           distribution: 'zulu'
           cache: 'maven'
       - name: Setup fuse
-        run: brew install macfuse
+        run: |
+          brew tap macos-fuse-t/homebrew-cask
+          brew update
+          brew install fuse-t
       - name: Maven build
-        run: mvn -B verify -Dfuse.lib.path="/usr/local/lib/libfuse.dylib"
+        run: mvn -B verify -Dfuse.lib.path="/usr/local/lib/libfuse-t.dylib"
       - uses: actions/upload-artifact@v3
         with:
           name: coverage-mac

--- a/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/MacFuseBuilder.java
+++ b/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/MacFuseBuilder.java
@@ -18,6 +18,8 @@ import java.nio.file.Path;
 @SupportedPlatform(os = OperatingSystem.MAC, arch = Architecture.ARM64)
 public class MacFuseBuilder implements FuseBuilder {
 
+	private static final String DEFAULT_MACFUSE_PATH = "/usr/local/lib/libfuse.dylib";
+	private static final String DEFAULT_FUSET_PATH = "/usr/local/lib/libfuse-t.dylib";
 	private static final Errno ERRNO = new MacErrno();
 	private String libraryPath;
 
@@ -41,6 +43,10 @@ public class MacFuseBuilder implements FuseBuilder {
 	public Fuse build(FuseOperations fuseOperations) throws UnsatisfiedLinkError {
 		if (libraryPath != null) {
 			System.load(libraryPath);
+		} else if (Files.exists(Path.of(DEFAULT_MACFUSE_PATH))) {
+			System.load(DEFAULT_MACFUSE_PATH);
+		} else if (Files.exists(Path.of(DEFAULT_FUSET_PATH))) {
+			System.load(DEFAULT_FUSET_PATH);
 		} else {
 			System.loadLibrary("fuse");
 		}


### PR DESCRIPTION
Since macOS 10.15 is not supported much longer, we use fuse-t instead, which allows us to continue doing integration tests with GitHub Actions.

This depends on #24, because fuse-t's mount function returns prematurely.