### PR TITLE
Extended Attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ Not all [`fuse_operations`](https://libfuse.github.io/doxygen/structfuse__operat
 | flush           | :white_check_mark:                      |
 | release         | :white_check_mark:                      |
 | fsync           | :white_check_mark:                      |
-| setxattr        | :x:                                     |
-| getxattr        | :x:                                     |
-| listxattr       | :x:                                     |
-| removexattr     | :x:                                     |
+| setxattr        | :white_check_mark:                      |
+| getxattr        | :white_check_mark:                      |
+| listxattr       | :white_check_mark:                      |
+| removexattr     | :white_check_mark:                      |
 | opendir         | :white_check_mark:                      |
 | readdir         | :white_check_mark:                      |
 | releasedir      | :white_check_mark:                      |

--- a/jfuse-api/src/main/java/org/cryptomator/jfuse/api/Errno.java
+++ b/jfuse-api/src/main/java/org/cryptomator/jfuse/api/Errno.java
@@ -95,4 +95,11 @@ public interface Errno {
 	 */
 	int einval();
 
+	/**
+	 * Result too large
+	 *
+	 * @return error constant {@code ERANGE}
+	 */
+	int erange();
+
 }

--- a/jfuse-api/src/main/java/org/cryptomator/jfuse/api/FuseOperations.java
+++ b/jfuse-api/src/main/java/org/cryptomator/jfuse/api/FuseOperations.java
@@ -23,7 +23,9 @@ public interface FuseOperations {
 		FSYNC,
 		FSYNCDIR,
 		GET_ATTR,
+		GET_XATTR,
 		INIT,
+		LIST_XATTR,
 		MKDIR,
 		OPEN,
 		OPEN_DIR,
@@ -32,8 +34,10 @@ public interface FuseOperations {
 		READ_DIR,
 		RELEASE,
 		RELEASE_DIR,
+		REMOVE_XATTR,
 		RENAME,
 		RMDIR,
+		SET_XATTR,
 		STATFS,
 		SYMLINK,
 		TRUNCATE,
@@ -404,12 +408,11 @@ public interface FuseOperations {
 	 * @param path  file path
 	 * @param name  attribute name
 	 * @param value attribute value
-	 * @param size  number of bytes of the value TODO: can this be combined with the value buffer?
 	 * @param flags defaults to zero, which creates <em>or</em> replaces the attribute. For fine-grained atomic control,
 	 *              <code>XATTR_CREATE</code> or <code>XATTR_REPLACE</code> may be used.
 	 * @return 0 on success or negated error code (-errno)
 	 */
-	default int setxattr(String path, String name, ByteBuffer value, long size, int flags) {
+	default int setxattr(String path, String name, ByteBuffer value, int flags) {
 		return -errno().enosys();
 	}
 
@@ -418,11 +421,10 @@ public interface FuseOperations {
 	 *
 	 * @param path  file path
 	 * @param name  attribute name
-	 * @param value attribute value
-	 * @param size  size of the value buffer TODO: can this be combined with the value buffer?
+	 * @param value attribute value. If buffer capacity is zero, return the size of the value
 	 * @return the non-negative value size or negated error code (-errno)
 	 */
-	default int getxattr(String path, String name, ByteBuffer value, long size) {
+	default int getxattr(String path, String name, ByteBuffer value) {
 		return -errno().enosys();
 	}
 
@@ -430,11 +432,10 @@ public interface FuseOperations {
 	 * List extended attributes
 	 *
 	 * @param path file path
-	 * @param list consecutive list of null-terminated attribute names (as many as fit into the buffer)
-	 * @param size size of the list buffer TODO: can this be combined with the value buffer?
-	 * @return the non-negative list size or negated error code (-errno)
+	 * @param list consecutive list of null-terminated attribute names (as many as fit into the buffer). If buffer capacity is zero, return the size of the list
+	 * @return the non-negative number of bytes written to the list buffer or negated error code (-errno)
 	 */
-	default int listxattr(String path, ByteBuffer list, long size) {
+	default int listxattr(String path, ByteBuffer list) {
 		return -errno().enosys();
 	}
 

--- a/jfuse-api/src/main/java/org/cryptomator/jfuse/api/FuseOperationsDecorator.java
+++ b/jfuse-api/src/main/java/org/cryptomator/jfuse/api/FuseOperationsDecorator.java
@@ -33,6 +33,26 @@ public interface FuseOperationsDecorator extends FuseOperations {
 	}
 
 	@Override
+	default int getxattr(String path, String name, ByteBuffer value) {
+		return delegate().getxattr(path, name, value);
+	}
+
+	@Override
+	default int setxattr(String path, String name, ByteBuffer value, int flags) {
+		return delegate().setxattr(path, name, value, flags);
+	}
+
+	@Override
+	default int listxattr(String path, ByteBuffer list) {
+		return delegate().listxattr(path, list);
+	}
+
+	@Override
+	default int removexattr(String path, String name) {
+		return delegate().removexattr(path, name);
+	}
+
+	@Override
 	default int readlink(String path, ByteBuffer buf, long len) {
 		return delegate().readlink(path, buf, len);
 	}

--- a/jfuse-examples/src/main/java/org/cryptomator/jfuse/examples/AbstractMirrorFileSystem.java
+++ b/jfuse-examples/src/main/java/org/cryptomator/jfuse/examples/AbstractMirrorFileSystem.java
@@ -38,6 +38,7 @@ import java.nio.file.attribute.FileTime;
 import java.nio.file.attribute.PosixFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.nio.file.attribute.UserDefinedFileAttributeView;
 import java.util.EnumSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -79,7 +80,9 @@ public abstract sealed class AbstractMirrorFileSystem implements FuseOperations 
 				FuseOperations.Operation.FSYNC,
 				FuseOperations.Operation.FSYNCDIR,
 				FuseOperations.Operation.GET_ATTR,
+				FuseOperations.Operation.GET_XATTR,
 				FuseOperations.Operation.INIT,
+				FuseOperations.Operation.LIST_XATTR,
 				FuseOperations.Operation.MKDIR,
 				FuseOperations.Operation.OPEN_DIR,
 				FuseOperations.Operation.READ_DIR,
@@ -90,6 +93,8 @@ public abstract sealed class AbstractMirrorFileSystem implements FuseOperations 
 				FuseOperations.Operation.READ,
 				FuseOperations.Operation.READLINK,
 				FuseOperations.Operation.RELEASE,
+				FuseOperations.Operation.REMOVE_XATTR,
+				FuseOperations.Operation.SET_XATTR,
 				FuseOperations.Operation.STATFS,
 				FuseOperations.Operation.SYMLINK,
 				FuseOperations.Operation.TRUNCATE,
@@ -186,6 +191,81 @@ public abstract sealed class AbstractMirrorFileSystem implements FuseOperations 
 		try {
 			var attrs = readAttributes(node);
 			copyAttrsToStat(attrs, stat);
+			return 0;
+		} catch (NoSuchFileException e) {
+			return -errno.enoent();
+		} catch (IOException e) {
+			return -errno.eio();
+		}
+	}
+
+	@Override
+	public int getxattr(String path, String name, ByteBuffer value) {
+		LOG.trace("getxattr {} {}", path, name);
+		Path node = resolvePath(path);
+		try {
+			var xattr = Files.getFileAttributeView(node, UserDefinedFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
+			int size = xattr.size(name);
+			if (value.capacity() == 0) {
+				return size;
+			} else if (value.remaining() < size) {
+				return -errno.erange();
+			} else {
+				return xattr.read(name, value);
+			}
+		} catch (NoSuchFileException e) {
+			return -errno.enoent();
+		} catch (IOException e) {
+			return -errno.eio();
+		}
+	}
+
+	@Override
+	public int setxattr(String path, String name, ByteBuffer value, int flags) {
+		LOG.trace("setxattr {} {}", path, name);
+		Path node = resolvePath(path);
+		try {
+			var xattr = Files.getFileAttributeView(node, UserDefinedFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
+			xattr.write(name, value);
+			return 0;
+		} catch (NoSuchFileException e) {
+			return -errno.enoent();
+		} catch (IOException e) {
+			return -errno.eio();
+		}
+	}
+
+	@Override
+	public int listxattr(String path, ByteBuffer list) {
+		LOG.trace("listxattr {}", path);
+		Path node = resolvePath(path);
+		try {
+			var xattr = Files.getFileAttributeView(node, UserDefinedFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
+			var names = xattr.list();
+			if (list.capacity() == 0) {
+				return names.size();
+			}
+			int startpos = list.position();
+			for (var name : names) {
+				list.put(StandardCharsets.UTF_8.encode(name)).put((byte) 0x00);
+			}
+			return list.position() - startpos;
+		} catch (BufferOverflowException e) {
+			return -errno.erange();
+		} catch (NoSuchFileException e) {
+			return -errno.enoent();
+		} catch (IOException e) {
+			return -errno.eio();
+		}
+	}
+
+	@Override
+	public int removexattr(String path, String name) {
+		LOG.trace("removexattr {} {}", path, name);
+		Path node = resolvePath(path);
+		try {
+			var xattr = Files.getFileAttributeView(node, UserDefinedFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
+			xattr.delete(name);
 			return 0;
 		} catch (NoSuchFileException e) {
 			return -errno.enoent();

--- a/jfuse-linux-aarch64/pom.xml
+++ b/jfuse-linux-aarch64/pom.xml
@@ -160,6 +160,7 @@
 										<includeMacro>EISDIR</includeMacro>
 										<includeMacro>ENOTEMPTY</includeMacro>
 										<includeMacro>EINVAL</includeMacro>
+										<includeMacro>ERANGE</includeMacro>
 									</includeMacros>
 								</configuration>
 							</execution>

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/FuseImpl.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/FuseImpl.java
@@ -79,6 +79,8 @@ final class FuseImpl extends Fuse {
 			case FSYNC -> fuse_operations.fsync$set(fuseOperationsStruct, fuse_operations.fsync.allocate(this::fsync, fuseScope).address());
 			case FSYNCDIR -> fuse_operations.fsyncdir$set(fuseOperationsStruct, fuse_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
 			case GET_ATTR -> fuse_operations.getattr$set(fuseOperationsStruct, fuse_operations.getattr.allocate(this::getattr, fuseScope).address());
+			case GET_XATTR -> fuse_operations.getxattr$set(fuseOperationsStruct, fuse_operations.getxattr.allocate(this::getxattr, fuseScope).address());
+			case LIST_XATTR -> fuse_operations.listxattr$set(fuseOperationsStruct, fuse_operations.listxattr.allocate(this::listxattr, fuseScope).address());
 			case MKDIR -> fuse_operations.mkdir$set(fuseOperationsStruct, fuse_operations.mkdir.allocate(this::mkdir, fuseScope).address());
 			case OPEN -> fuse_operations.open$set(fuseOperationsStruct, fuse_operations.open.allocate(this::open, fuseScope).address());
 			case OPEN_DIR -> fuse_operations.opendir$set(fuseOperationsStruct, fuse_operations.opendir.allocate(this::opendir, fuseScope).address());
@@ -87,8 +89,10 @@ final class FuseImpl extends Fuse {
 			case READLINK -> fuse_operations.readlink$set(fuseOperationsStruct, fuse_operations.readlink.allocate(this::readlink, fuseScope).address());
 			case RELEASE -> fuse_operations.release$set(fuseOperationsStruct, fuse_operations.release.allocate(this::release, fuseScope).address());
 			case RELEASE_DIR -> fuse_operations.releasedir$set(fuseOperationsStruct, fuse_operations.releasedir.allocate(this::releasedir, fuseScope).address());
+			case REMOVE_XATTR -> fuse_operations.removexattr$set(fuseOperationsStruct, fuse_operations.removexattr.allocate(this::removexattr, fuseScope).address());
 			case RENAME -> fuse_operations.rename$set(fuseOperationsStruct, fuse_operations.rename.allocate(this::rename, fuseScope).address());
 			case RMDIR -> fuse_operations.rmdir$set(fuseOperationsStruct, fuse_operations.rmdir.allocate(this::rmdir, fuseScope).address());
+			case SET_XATTR -> fuse_operations.setxattr$set(fuseOperationsStruct, fuse_operations.setxattr.allocate(this::setxattr, fuseScope).address());
 			case STATFS -> fuse_operations.statfs$set(fuseOperationsStruct, fuse_operations.statfs.allocate(this::statfs, fuseScope).address());
 			case SYMLINK -> fuse_operations.symlink$set(fuseOperationsStruct, fuse_operations.symlink.allocate(this::symlink, fuseScope).address());
 			case TRUNCATE -> fuse_operations.truncate$set(fuseOperationsStruct, fuse_operations.truncate.allocate(this::truncate, fuseScope).address());
@@ -161,6 +165,32 @@ final class FuseImpl extends Fuse {
 		try (var scope = MemorySession.openConfined()) {
 			return fuseOperations.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
 		}
+	}
+
+	@VisibleForTesting
+	int getxattr(MemoryAddress path, MemoryAddress name, MemoryAddress value, long size) {
+		try (var scope = MemorySession.openConfined()) {
+			return fuseOperations.getxattr(path.getUtf8String(0), name.getUtf8String(0), MemorySegment.ofAddress(value.address(), size, scope).asByteBuffer());
+		}
+	}
+
+	@VisibleForTesting
+	int setxattr(MemoryAddress path, MemoryAddress name, MemoryAddress value, long size, int flags) {
+		try (var scope = MemorySession.openConfined()) {
+			return fuseOperations.setxattr(path.getUtf8String(0), name.getUtf8String(0), MemorySegment.ofAddress(value.address(), size, scope).asByteBuffer(), flags);
+		}
+	}
+
+	@VisibleForTesting
+	int listxattr(MemoryAddress path, MemoryAddress value, long size) {
+		try (var scope = MemorySession.openConfined()) {
+			return fuseOperations.listxattr(path.getUtf8String(0), MemorySegment.ofAddress(value.address(), size, scope).asByteBuffer());
+		}
+	}
+
+	@VisibleForTesting
+	int removexattr(MemoryAddress path, MemoryAddress name) {
+		return fuseOperations.removexattr(path.getUtf8String(0), name.getUtf8String(0));
 	}
 
 	private int mkdir(MemoryAddress path, int mode) {

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/LinuxErrno.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/LinuxErrno.java
@@ -64,4 +64,9 @@ record LinuxErrno() implements Errno {
 	public int einval() {
 		return errno_h.EINVAL();
 	}
+
+	@Override
+	public int erange() {
+		return errno_h.ERANGE();
+	}
 }

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/errno_h.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/errno_h.java
@@ -48,6 +48,9 @@ public class errno_h  {
     public static int EROFS() {
         return (int)30L;
     }
+    public static int ERANGE() {
+        return (int)34L;
+    }
     public static int ENOSYS() {
         return (int)38L;
     }

--- a/jfuse-linux-aarch64/src/test/java/org/cryptomator/jfuse/linux/aarch64/FuseImplTest.java
+++ b/jfuse-linux-aarch64/src/test/java/org/cryptomator/jfuse/linux/aarch64/FuseImplTest.java
@@ -234,6 +234,74 @@ public class FuseImplTest {
 		}
 	}
 
+	@Nested
+	@DisplayName("attr")
+	public class Attr {
+
+		@Test
+		@DisplayName("getxattr")
+		public void testGetxattr() {
+			try (var scope = MemorySession.openConfined()) {
+				var path = scope.allocateUtf8String("/foo");
+				var name = scope.allocateUtf8String("bar");
+				var value = scope.allocate(100);
+
+				Mockito.doReturn(42).when(fuseOps).getxattr(Mockito.eq("/foo"), Mockito.eq("bar"), Mockito.any());
+
+				var result = fuseImpl.getxattr(path.address(), name.address(), value.address(), 100);
+
+				Assertions.assertEquals(42, result);
+			}
+		}
+
+		@Test
+		@DisplayName("setxattr")
+		public void testSetxattr() {
+			try (var scope = MemorySession.openConfined()) {
+				var path = scope.allocateUtf8String("/foo");
+				var name = scope.allocateUtf8String("bar");
+				var value = scope.allocate(100);
+
+				Mockito.doReturn(42).when(fuseOps).setxattr(Mockito.eq("/foo"), Mockito.eq("bar"), Mockito.any(), Mockito.anyInt());
+
+				var result = fuseImpl.setxattr(path.address(), name.address(), value.address(), 100, 0xDEADBEEF);
+
+				Assertions.assertEquals(42, result);
+			}
+		}
+
+		@Test
+		@DisplayName("listxattr")
+		public void testListxattr() {
+			try (var scope = MemorySession.openConfined()) {
+				var path = scope.allocateUtf8String("/foo");
+				var list = scope.allocate(100);
+
+				Mockito.doReturn(42).when(fuseOps).listxattr(Mockito.eq("/foo"), Mockito.any());
+
+				var result = fuseImpl.listxattr(path.address(), list.address(), 100);
+
+				Assertions.assertEquals(42, result);
+			}
+		}
+
+		@Test
+		@DisplayName("removexattr")
+		public void testRemovexattr() {
+			try (var scope = MemorySession.openConfined()) {
+				var path = scope.allocateUtf8String("/foo");
+				var name = scope.allocateUtf8String("bar");
+
+				Mockito.doReturn(42).when(fuseOps).removexattr(Mockito.eq("/foo"), Mockito.eq("bar"));
+
+				var result = fuseImpl.removexattr(path.address(), name.address());
+
+				Assertions.assertEquals(42, result);
+			}
+		}
+
+	}
+
 	@Test
 	@DisplayName("chown")
 	public void testChown() {

--- a/jfuse-linux-amd64/pom.xml
+++ b/jfuse-linux-amd64/pom.xml
@@ -160,6 +160,7 @@
 										<includeMacro>EISDIR</includeMacro>
 										<includeMacro>ENOTEMPTY</includeMacro>
 										<includeMacro>EINVAL</includeMacro>
+										<includeMacro>ERANGE</includeMacro>
 									</includeMacros>
 								</configuration>
 							</execution>

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/FuseImpl.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/FuseImpl.java
@@ -79,6 +79,8 @@ final class FuseImpl extends Fuse {
 			case FSYNC -> fuse_operations.fsync$set(fuseOperationsStruct, fuse_operations.fsync.allocate(this::fsync, fuseScope).address());
 			case FSYNCDIR -> fuse_operations.fsyncdir$set(fuseOperationsStruct, fuse_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
 			case GET_ATTR -> fuse_operations.getattr$set(fuseOperationsStruct, fuse_operations.getattr.allocate(this::getattr, fuseScope).address());
+			case GET_XATTR -> fuse_operations.getxattr$set(fuseOperationsStruct, fuse_operations.getxattr.allocate(this::getxattr, fuseScope).address());
+			case LIST_XATTR -> fuse_operations.listxattr$set(fuseOperationsStruct, fuse_operations.listxattr.allocate(this::listxattr, fuseScope).address());
 			case MKDIR -> fuse_operations.mkdir$set(fuseOperationsStruct, fuse_operations.mkdir.allocate(this::mkdir, fuseScope).address());
 			case OPEN -> fuse_operations.open$set(fuseOperationsStruct, fuse_operations.open.allocate(this::open, fuseScope).address());
 			case OPEN_DIR -> fuse_operations.opendir$set(fuseOperationsStruct, fuse_operations.opendir.allocate(this::opendir, fuseScope).address());
@@ -87,8 +89,10 @@ final class FuseImpl extends Fuse {
 			case READLINK -> fuse_operations.readlink$set(fuseOperationsStruct, fuse_operations.readlink.allocate(this::readlink, fuseScope).address());
 			case RELEASE -> fuse_operations.release$set(fuseOperationsStruct, fuse_operations.release.allocate(this::release, fuseScope).address());
 			case RELEASE_DIR -> fuse_operations.releasedir$set(fuseOperationsStruct, fuse_operations.releasedir.allocate(this::releasedir, fuseScope).address());
+			case REMOVE_XATTR -> fuse_operations.removexattr$set(fuseOperationsStruct, fuse_operations.removexattr.allocate(this::removexattr, fuseScope).address());
 			case RENAME -> fuse_operations.rename$set(fuseOperationsStruct, fuse_operations.rename.allocate(this::rename, fuseScope).address());
 			case RMDIR -> fuse_operations.rmdir$set(fuseOperationsStruct, fuse_operations.rmdir.allocate(this::rmdir, fuseScope).address());
+			case SET_XATTR -> fuse_operations.setxattr$set(fuseOperationsStruct, fuse_operations.setxattr.allocate(this::setxattr, fuseScope).address());
 			case STATFS -> fuse_operations.statfs$set(fuseOperationsStruct, fuse_operations.statfs.allocate(this::statfs, fuseScope).address());
 			case SYMLINK -> fuse_operations.symlink$set(fuseOperationsStruct, fuse_operations.symlink.allocate(this::symlink, fuseScope).address());
 			case TRUNCATE -> fuse_operations.truncate$set(fuseOperationsStruct, fuse_operations.truncate.allocate(this::truncate, fuseScope).address());
@@ -161,6 +165,32 @@ final class FuseImpl extends Fuse {
 		try (var scope = MemorySession.openConfined()) {
 			return fuseOperations.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
 		}
+	}
+
+	@VisibleForTesting
+	int getxattr(MemoryAddress path, MemoryAddress name, MemoryAddress value, long size) {
+		try (var scope = MemorySession.openConfined()) {
+			return fuseOperations.getxattr(path.getUtf8String(0), name.getUtf8String(0), MemorySegment.ofAddress(value.address(), size, scope).asByteBuffer());
+		}
+	}
+
+	@VisibleForTesting
+	int setxattr(MemoryAddress path, MemoryAddress name, MemoryAddress value, long size, int flags) {
+		try (var scope = MemorySession.openConfined()) {
+			return fuseOperations.setxattr(path.getUtf8String(0), name.getUtf8String(0), MemorySegment.ofAddress(value.address(), size, scope).asByteBuffer(), flags);
+		}
+	}
+
+	@VisibleForTesting
+	int listxattr(MemoryAddress path, MemoryAddress value, long size) {
+		try (var scope = MemorySession.openConfined()) {
+			return fuseOperations.listxattr(path.getUtf8String(0), MemorySegment.ofAddress(value.address(), size, scope).asByteBuffer());
+		}
+	}
+
+	@VisibleForTesting
+	int removexattr(MemoryAddress path, MemoryAddress name) {
+		return fuseOperations.removexattr(path.getUtf8String(0), name.getUtf8String(0));
 	}
 
 	private int mkdir(MemoryAddress path, int mode) {

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/LinuxErrno.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/LinuxErrno.java
@@ -64,4 +64,9 @@ record LinuxErrno() implements Errno {
 	public int einval() {
 		return errno_h.EINVAL();
 	}
+
+	@Override
+	public int erange() {
+		return errno_h.ERANGE();
+	}
 }

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/errno_h.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/errno_h.java
@@ -48,6 +48,9 @@ public class errno_h  {
     public static int EROFS() {
         return (int)30L;
     }
+    public static int ERANGE() {
+        return (int)34L;
+    }
     public static int ENOSYS() {
         return (int)38L;
     }

--- a/jfuse-linux-amd64/src/test/java/org/cryptomator/jfuse/linux/amd64/FuseImplTest.java
+++ b/jfuse-linux-amd64/src/test/java/org/cryptomator/jfuse/linux/amd64/FuseImplTest.java
@@ -234,6 +234,74 @@ public class FuseImplTest {
 		}
 	}
 
+	@Nested
+	@DisplayName("attr")
+	public class Attr {
+
+		@Test
+		@DisplayName("getxattr")
+		public void testGetxattr() {
+			try (var scope = MemorySession.openConfined()) {
+				var path = scope.allocateUtf8String("/foo");
+				var name = scope.allocateUtf8String("bar");
+				var value = scope.allocate(100);
+
+				Mockito.doReturn(42).when(fuseOps).getxattr(Mockito.eq("/foo"), Mockito.eq("bar"), Mockito.any());
+
+				var result = fuseImpl.getxattr(path.address(), name.address(), value.address(), 100);
+
+				Assertions.assertEquals(42, result);
+			}
+		}
+
+		@Test
+		@DisplayName("setxattr")
+		public void testSetxattr() {
+			try (var scope = MemorySession.openConfined()) {
+				var path = scope.allocateUtf8String("/foo");
+				var name = scope.allocateUtf8String("bar");
+				var value = scope.allocate(100);
+
+				Mockito.doReturn(42).when(fuseOps).setxattr(Mockito.eq("/foo"), Mockito.eq("bar"), Mockito.any(), Mockito.anyInt());
+
+				var result = fuseImpl.setxattr(path.address(), name.address(), value.address(), 100, 0xDEADBEEF);
+
+				Assertions.assertEquals(42, result);
+			}
+		}
+
+		@Test
+		@DisplayName("listxattr")
+		public void testListxattr() {
+			try (var scope = MemorySession.openConfined()) {
+				var path = scope.allocateUtf8String("/foo");
+				var list = scope.allocate(100);
+
+				Mockito.doReturn(42).when(fuseOps).listxattr(Mockito.eq("/foo"), Mockito.any());
+
+				var result = fuseImpl.listxattr(path.address(), list.address(), 100);
+
+				Assertions.assertEquals(42, result);
+			}
+		}
+
+		@Test
+		@DisplayName("removexattr")
+		public void testRemovexattr() {
+			try (var scope = MemorySession.openConfined()) {
+				var path = scope.allocateUtf8String("/foo");
+				var name = scope.allocateUtf8String("bar");
+
+				Mockito.doReturn(42).when(fuseOps).removexattr(Mockito.eq("/foo"), Mockito.eq("bar"));
+
+				var result = fuseImpl.removexattr(path.address(), name.address());
+
+				Assertions.assertEquals(42, result);
+			}
+		}
+
+	}
+
 	@Test
 	@DisplayName("chown")
 	public void testChown() {

--- a/jfuse-mac/pom.xml
+++ b/jfuse-mac/pom.xml
@@ -134,6 +134,7 @@
 										<includeMacro>EISDIR</includeMacro>
 										<includeMacro>ENOTEMPTY</includeMacro>
 										<includeMacro>EINVAL</includeMacro>
+										<includeMacro>ERANGE</includeMacro>
 									</includeMacros>
 								</configuration>
 							</execution>

--- a/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/FuseImpl.java
+++ b/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/FuseImpl.java
@@ -84,6 +84,8 @@ final class FuseImpl extends Fuse {
 				fuse_operations.getattr$set(fuseOperationsStruct, fuse_operations.getattr.allocate(this::getattr, fuseScope).address());
 				fuse_operations.fgetattr$set(fuseOperationsStruct, fuse_operations.fgetattr.allocate(this::fgetattr, fuseScope).address());
 			}
+			case GET_XATTR -> fuse_operations.getxattr$set(fuseOperationsStruct, fuse_operations.getxattr.allocate(this::getxattr, fuseScope).address());
+			case LIST_XATTR -> fuse_operations.listxattr$set(fuseOperationsStruct, fuse_operations.listxattr.allocate(this::listxattr, fuseScope).address());
 			case MKDIR -> fuse_operations.mkdir$set(fuseOperationsStruct, fuse_operations.mkdir.allocate(this::mkdir, fuseScope).address());
 			case OPEN -> fuse_operations.open$set(fuseOperationsStruct, fuse_operations.open.allocate(this::open, fuseScope).address());
 			case OPEN_DIR -> fuse_operations.opendir$set(fuseOperationsStruct, fuse_operations.opendir.allocate(this::opendir, fuseScope).address());
@@ -92,8 +94,10 @@ final class FuseImpl extends Fuse {
 			case READLINK -> fuse_operations.readlink$set(fuseOperationsStruct, fuse_operations.readlink.allocate(this::readlink, fuseScope).address());
 			case RELEASE -> fuse_operations.release$set(fuseOperationsStruct, fuse_operations.release.allocate(this::release, fuseScope).address());
 			case RELEASE_DIR -> fuse_operations.releasedir$set(fuseOperationsStruct, fuse_operations.releasedir.allocate(this::releasedir, fuseScope).address());
+			case REMOVE_XATTR -> fuse_operations.removexattr$set(fuseOperationsStruct, fuse_operations.removexattr.allocate(this::removexattr, fuseScope).address());
 			case RENAME -> fuse_operations.rename$set(fuseOperationsStruct, fuse_operations.rename.allocate(this::rename, fuseScope).address());
 			case RMDIR -> fuse_operations.rmdir$set(fuseOperationsStruct, fuse_operations.rmdir.allocate(this::rmdir, fuseScope).address());
+			case SET_XATTR -> fuse_operations.setxattr$set(fuseOperationsStruct, fuse_operations.setxattr.allocate(this::setxattr, fuseScope).address());
 			case STATFS -> fuse_operations.statfs$set(fuseOperationsStruct, fuse_operations.statfs.allocate(this::statfs, fuseScope).address());
 			case SYMLINK -> fuse_operations.symlink$set(fuseOperationsStruct, fuse_operations.symlink.allocate(this::symlink, fuseScope).address());
 			case TRUNCATE -> {
@@ -169,6 +173,32 @@ final class FuseImpl extends Fuse {
 		try (var scope = MemorySession.openConfined()) {
 			return fuseOperations.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
 		}
+	}
+
+	@VisibleForTesting
+	int getxattr(MemoryAddress path, MemoryAddress name, MemoryAddress value, long size) {
+		try (var scope = MemorySession.openConfined()) {
+			return fuseOperations.getxattr(path.getUtf8String(0), name.getUtf8String(0), MemorySegment.ofAddress(value.address(), size, scope).asByteBuffer());
+		}
+	}
+
+	@VisibleForTesting
+	int setxattr(MemoryAddress path, MemoryAddress name, MemoryAddress value, long size, int flags) {
+		try (var scope = MemorySession.openConfined()) {
+			return fuseOperations.setxattr(path.getUtf8String(0), name.getUtf8String(0), MemorySegment.ofAddress(value.address(), size, scope).asByteBuffer(), flags);
+		}
+	}
+
+	@VisibleForTesting
+	int listxattr(MemoryAddress path, MemoryAddress value, long size) {
+		try (var scope = MemorySession.openConfined()) {
+			return fuseOperations.listxattr(path.getUtf8String(0), MemorySegment.ofAddress(value.address(), size, scope).asByteBuffer());
+		}
+	}
+
+	@VisibleForTesting
+	int removexattr(MemoryAddress path, MemoryAddress name) {
+		return fuseOperations.removexattr(path.getUtf8String(0), name.getUtf8String(0));
 	}
 
 	private int mkdir(MemoryAddress path, short mode) {

--- a/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/MacErrno.java
+++ b/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/MacErrno.java
@@ -64,4 +64,9 @@ record MacErrno() implements Errno {
 	public int einval() {
 		return errno_h.EINVAL();
 	}
+
+	@Override
+	public int erange() {
+		return errno_h.ERANGE();
+	}
 }

--- a/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/extr/errno_h.java
+++ b/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/extr/errno_h.java
@@ -48,6 +48,9 @@ public class errno_h  {
     public static int EROFS() {
         return (int)30L;
     }
+    public static int ERANGE() {
+        return (int)34L;
+    }
     public static int ENOTEMPTY() {
         return (int)66L;
     }

--- a/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/extr/stat_h.java
+++ b/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/extr/stat_h.java
@@ -18,15 +18,6 @@ public class stat_h  {
     public static OfFloat C_FLOAT = Constants$root.C_FLOAT$LAYOUT;
     public static OfDouble C_DOUBLE = Constants$root.C_DOUBLE$LAYOUT;
     public static OfAddress C_POINTER = Constants$root.C_POINTER$LAYOUT;
-    public static int S_IFDIR() {
-        return (int)16384L;
-    }
-    public static int S_IFREG() {
-        return (int)32768L;
-    }
-    public static int S_IFLNK() {
-        return (int)40960L;
-    }
     public static int UTIME_NOW() {
         return (int)-1L;
     }

--- a/jfuse-mac/src/test/java/org/cryptomator/jfuse/mac/FuseImplTest.java
+++ b/jfuse-mac/src/test/java/org/cryptomator/jfuse/mac/FuseImplTest.java
@@ -193,8 +193,8 @@ public class FuseImplTest {
 	}
 
 	@Nested
-	@DisplayName("getattr")
-	public class GetAttr {
+	@DisplayName("attr")
+	public class Attr {
 
 		@Test
 		@DisplayName("getattr")
@@ -220,6 +220,68 @@ public class FuseImplTest {
 				Mockito.doReturn(42).when(fuseOps).getattr(Mockito.eq("/foo"), Mockito.any(), Mockito.notNull());
 
 				var result = fuseImpl.fgetattr(path.address(), attr.address(), fi.address());
+
+				Assertions.assertEquals(42, result);
+			}
+		}
+
+		@Test
+		@DisplayName("getxattr")
+		public void testGetxattr() {
+			try (var scope = MemorySession.openConfined()) {
+				var path = scope.allocateUtf8String("/foo");
+				var name = scope.allocateUtf8String("bar");
+				var value = scope.allocate(100);
+
+				Mockito.doReturn(42).when(fuseOps).getxattr(Mockito.eq("/foo"), Mockito.eq("bar"), Mockito.any());
+
+				var result = fuseImpl.getxattr(path.address(), name.address(), value.address(), 100);
+
+				Assertions.assertEquals(42, result);
+			}
+		}
+
+		@Test
+		@DisplayName("setxattr")
+		public void testSetxattr() {
+			try (var scope = MemorySession.openConfined()) {
+				var path = scope.allocateUtf8String("/foo");
+				var name = scope.allocateUtf8String("bar");
+				var value = scope.allocate(100);
+
+				Mockito.doReturn(42).when(fuseOps).setxattr(Mockito.eq("/foo"), Mockito.eq("bar"), Mockito.any(), Mockito.anyInt());
+
+				var result = fuseImpl.setxattr(path.address(), name.address(), value.address(), 100, 0xDEADBEEF);
+
+				Assertions.assertEquals(42, result);
+			}
+		}
+
+		@Test
+		@DisplayName("listxattr")
+		public void testListxattr() {
+			try (var scope = MemorySession.openConfined()) {
+				var path = scope.allocateUtf8String("/foo");
+				var list = scope.allocate(100);
+
+				Mockito.doReturn(42).when(fuseOps).listxattr(Mockito.eq("/foo"), Mockito.any());
+
+				var result = fuseImpl.listxattr(path.address(), list.address(), 100);
+
+				Assertions.assertEquals(42, result);
+			}
+		}
+
+		@Test
+		@DisplayName("removexattr")
+		public void testRemovexattr() {
+			try (var scope = MemorySession.openConfined()) {
+				var path = scope.allocateUtf8String("/foo");
+				var name = scope.allocateUtf8String("bar");
+
+				Mockito.doReturn(42).when(fuseOps).removexattr(Mockito.eq("/foo"), Mockito.eq("bar"));
+
+				var result = fuseImpl.removexattr(path.address(), name.address());
 
 				Assertions.assertEquals(42, result);
 			}

--- a/jfuse-tests/src/test/java/org/cryptomator/jfuse/tests/MirrorIT.java
+++ b/jfuse-tests/src/test/java/org/cryptomator/jfuse/tests/MirrorIT.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
@@ -205,6 +206,7 @@ public class MirrorIT {
 
 
 	@Nested
+	@DisabledOnOs(OS.WINDOWS) // see remark on https://github.com/cryptomator/jfuse/pull/26
 	@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 	@DisplayName("Extended Attributes")

--- a/jfuse-tests/src/test/java/org/cryptomator/jfuse/tests/MirrorIT.java
+++ b/jfuse-tests/src/test/java/org/cryptomator/jfuse/tests/MirrorIT.java
@@ -84,7 +84,6 @@ public class MirrorIT {
 			}
 			default -> throw new FuseMountFailedException("Unsupported OS");
 		};
-		flags.add("-onoattrcache");
 		fuse = builder.build(fs);
 		fuse.mount("mirror-it", mirror, flags.toArray(String[]::new));
 	}

--- a/jfuse-win/pom.xml
+++ b/jfuse-win/pom.xml
@@ -154,6 +154,7 @@
 										<includeMacro>EISDIR</includeMacro>
 										<includeMacro>ENOTEMPTY</includeMacro>
 										<includeMacro>EINVAL</includeMacro>
+										<includeMacro>ERANGE</includeMacro>
 									</includeMacros>
 								</configuration>
 							</execution>

--- a/jfuse-win/src/main/java/org/cryptomator/jfuse/win/FuseImpl.java
+++ b/jfuse-win/src/main/java/org/cryptomator/jfuse/win/FuseImpl.java
@@ -91,6 +91,8 @@ class FuseImpl extends Fuse {
 			case FSYNC -> fuse3_operations.fsync$set(fuseOperationsStruct, fuse3_operations.fsync.allocate(this::fsync, fuseScope).address());
 			case FSYNCDIR -> fuse3_operations.fsyncdir$set(fuseOperationsStruct, fuse3_operations.fsyncdir.allocate(this::fsyncdir, fuseScope).address());
 			case GET_ATTR -> fuse3_operations.getattr$set(fuseOperationsStruct, fuse3_operations.getattr.allocate(this::getattr, fuseScope).address());
+			case GET_XATTR -> fuse3_operations.getxattr$set(fuseOperationsStruct, fuse3_operations.getxattr.allocate(this::getxattr, fuseScope).address());
+			case LIST_XATTR -> fuse3_operations.listxattr$set(fuseOperationsStruct, fuse3_operations.listxattr.allocate(this::listxattr, fuseScope).address());
 			case MKDIR -> fuse3_operations.mkdir$set(fuseOperationsStruct, fuse3_operations.mkdir.allocate(this::mkdir, fuseScope).address());
 			case OPEN -> fuse3_operations.open$set(fuseOperationsStruct, fuse3_operations.open.allocate(this::open, fuseScope).address());
 			case OPEN_DIR -> fuse3_operations.opendir$set(fuseOperationsStruct, fuse3_operations.opendir.allocate(this::opendir, fuseScope).address());
@@ -99,8 +101,10 @@ class FuseImpl extends Fuse {
 			case READLINK -> fuse3_operations.readlink$set(fuseOperationsStruct, fuse3_operations.readlink.allocate(this::readlink, fuseScope).address());
 			case RELEASE -> fuse3_operations.release$set(fuseOperationsStruct, fuse3_operations.release.allocate(this::release, fuseScope).address());
 			case RELEASE_DIR -> fuse3_operations.releasedir$set(fuseOperationsStruct, fuse3_operations.releasedir.allocate(this::releasedir, fuseScope).address());
+			case REMOVE_XATTR -> fuse3_operations.removexattr$set(fuseOperationsStruct, fuse3_operations.removexattr.allocate(this::removexattr, fuseScope).address());
 			case RENAME -> fuse3_operations.rename$set(fuseOperationsStruct, fuse3_operations.rename.allocate(this::rename, fuseScope).address());
 			case RMDIR -> fuse3_operations.rmdir$set(fuseOperationsStruct, fuse3_operations.rmdir.allocate(this::rmdir, fuseScope).address());
+			case SET_XATTR -> fuse3_operations.setxattr$set(fuseOperationsStruct, fuse3_operations.setxattr.allocate(this::setxattr, fuseScope).address());
 			case STATFS -> fuse3_operations.statfs$set(fuseOperationsStruct, fuse3_operations.statfs.allocate(this::statfs, fuseScope).address());
 			case SYMLINK -> fuse3_operations.symlink$set(fuseOperationsStruct, fuse3_operations.symlink.allocate(this::symlink, fuseScope).address());
 			case TRUNCATE -> fuse3_operations.truncate$set(fuseOperationsStruct, fuse3_operations.truncate.allocate(this::truncate, fuseScope).address());
@@ -170,6 +174,32 @@ class FuseImpl extends Fuse {
 		try (var scope = MemorySession.openConfined()) {
 			return fuseOperations.getattr(path.getUtf8String(0), new StatImpl(stat, scope), new FileInfoImpl(fi, scope));
 		}
+	}
+
+	@VisibleForTesting
+	int getxattr(MemoryAddress path, MemoryAddress name, MemoryAddress value, long size) {
+		try (var scope = MemorySession.openConfined()) {
+			return fuseOperations.getxattr(path.getUtf8String(0), name.getUtf8String(0), MemorySegment.ofAddress(value.address(), size, scope).asByteBuffer());
+		}
+	}
+
+	@VisibleForTesting
+	int setxattr(MemoryAddress path, MemoryAddress name, MemoryAddress value, long size, int flags) {
+		try (var scope = MemorySession.openConfined()) {
+			return fuseOperations.setxattr(path.getUtf8String(0), name.getUtf8String(0), MemorySegment.ofAddress(value.address(), size, scope).asByteBuffer(), flags);
+		}
+	}
+
+	@VisibleForTesting
+	int listxattr(MemoryAddress path, MemoryAddress value, long size) {
+		try (var scope = MemorySession.openConfined()) {
+			return fuseOperations.listxattr(path.getUtf8String(0), MemorySegment.ofAddress(value.address(), size, scope).asByteBuffer());
+		}
+	}
+
+	@VisibleForTesting
+	int removexattr(MemoryAddress path, MemoryAddress name) {
+		return fuseOperations.removexattr(path.getUtf8String(0), name.getUtf8String(0));
 	}
 
 	private int mkdir(MemoryAddress path, int mode) {

--- a/jfuse-win/src/main/java/org/cryptomator/jfuse/win/WinErrno.java
+++ b/jfuse-win/src/main/java/org/cryptomator/jfuse/win/WinErrno.java
@@ -64,4 +64,9 @@ record WinErrno() implements Errno {
 	public int einval() {
 		return errno_h.EINVAL();
 	}
+
+	@Override
+	public int erange() {
+		return errno_h.ERANGE();
+	}
 }

--- a/jfuse-win/src/main/java/org/cryptomator/jfuse/win/extr/errno_h.java
+++ b/jfuse-win/src/main/java/org/cryptomator/jfuse/win/extr/errno_h.java
@@ -41,6 +41,9 @@ public class errno_h  {
     public static int EROFS() {
         return (int)30L;
     }
+    public static int ERANGE() {
+        return (int)34L;
+    }
     public static int ENOSYS() {
         return (int)40L;
     }

--- a/jfuse-win/src/test/java/org/cryptomator/jfuse/win/FuseImplTest.java
+++ b/jfuse-win/src/test/java/org/cryptomator/jfuse/win/FuseImplTest.java
@@ -227,19 +227,87 @@ public class FuseImplTest {
 		}
 	}
 
-	@Test
-	@DisplayName("getattr")
-	public void testGetattr() {
-		try (var scope = MemorySession.openConfined()) {
-			var path = scope.allocateUtf8String("/foo");
-			var attr = fuse_stat.allocate(scope);
-			var fi = scope.allocate(fuse3_file_info.$LAYOUT());
-			Mockito.doReturn(42).when(fuseOps).getattr(Mockito.eq("/foo"), Mockito.any(), Mockito.argThat(usesSameMemorySegement(fi)));
+	@Nested
+	@DisplayName("attr")
+	public class Attr {
 
-			var result = fuseImpl.getattr(path.address(), attr.address(), fi.address());
+		@Test
+		@DisplayName("getattr")
+		public void testGetattr() {
+			try (var scope = MemorySession.openConfined()) {
+				var path = scope.allocateUtf8String("/foo");
+				var attr = fuse_stat.allocate(scope);
+				var fi = scope.allocate(fuse3_file_info.$LAYOUT());
+				Mockito.doReturn(42).when(fuseOps).getattr(Mockito.eq("/foo"), Mockito.any(), Mockito.argThat(usesSameMemorySegement(fi)));
 
-			Assertions.assertEquals(42, result);
+				var result = fuseImpl.getattr(path.address(), attr.address(), fi.address());
+
+				Assertions.assertEquals(42, result);
+			}
 		}
+
+		@Test
+		@DisplayName("getxattr")
+		public void testGetxattr() {
+			try (var scope = MemorySession.openConfined()) {
+				var path = scope.allocateUtf8String("/foo");
+				var name = scope.allocateUtf8String("bar");
+				var value = scope.allocate(100);
+
+				Mockito.doReturn(42).when(fuseOps).getxattr(Mockito.eq("/foo"), Mockito.eq("bar"), Mockito.any());
+
+				var result = fuseImpl.getxattr(path.address(), name.address(), value.address(), 100);
+
+				Assertions.assertEquals(42, result);
+			}
+		}
+
+		@Test
+		@DisplayName("setxattr")
+		public void testSetxattr() {
+			try (var scope = MemorySession.openConfined()) {
+				var path = scope.allocateUtf8String("/foo");
+				var name = scope.allocateUtf8String("bar");
+				var value = scope.allocate(100);
+
+				Mockito.doReturn(42).when(fuseOps).setxattr(Mockito.eq("/foo"), Mockito.eq("bar"), Mockito.any(), Mockito.anyInt());
+
+				var result = fuseImpl.setxattr(path.address(), name.address(), value.address(), 100, 0xDEADBEEF);
+
+				Assertions.assertEquals(42, result);
+			}
+		}
+
+		@Test
+		@DisplayName("listxattr")
+		public void testListxattr() {
+			try (var scope = MemorySession.openConfined()) {
+				var path = scope.allocateUtf8String("/foo");
+				var list = scope.allocate(100);
+
+				Mockito.doReturn(42).when(fuseOps).listxattr(Mockito.eq("/foo"), Mockito.any());
+
+				var result = fuseImpl.listxattr(path.address(), list.address(), 100);
+
+				Assertions.assertEquals(42, result);
+			}
+		}
+
+		@Test
+		@DisplayName("removexattr")
+		public void testRemovexattr() {
+			try (var scope = MemorySession.openConfined()) {
+				var path = scope.allocateUtf8String("/foo");
+				var name = scope.allocateUtf8String("bar");
+
+				Mockito.doReturn(42).when(fuseOps).removexattr(Mockito.eq("/foo"), Mockito.eq("bar"));
+
+				var result = fuseImpl.removexattr(path.address(), name.address());
+
+				Assertions.assertEquals(42, result);
+			}
+		}
+
 	}
 
 


### PR DESCRIPTION
fixes #6.

**Note**: The integration tests are disabled on Windows, because `UserDefinedFileAttributeView` doesn't rely on xattr but alternate data streams. Maybe we can find a different way to specifically test xattr, probably via some external process. 