### PR TITLE
Add error codes: ENLCK and ENAMETOOLONG

### DIFF
--- a/jfuse-api/src/main/java/org/cryptomator/jfuse/api/Errno.java
+++ b/jfuse-api/src/main/java/org/cryptomator/jfuse/api/Errno.java
@@ -109,4 +109,19 @@ public interface Errno {
 	 */
 	int erange();
 
+
+	/**
+	 * No locks available
+	 *
+	 * @return error constant {@code ENOLCK}
+	 */
+	int ernolck();
+
+	/**
+	 * Filename too long
+	 *
+	 * @return error constant {@code ENAMETOOLONG}
+	 */
+	int enametoolong();
+
 }

--- a/jfuse-api/src/main/java/org/cryptomator/jfuse/api/Errno.java
+++ b/jfuse-api/src/main/java/org/cryptomator/jfuse/api/Errno.java
@@ -115,7 +115,7 @@ public interface Errno {
 	 *
 	 * @return error constant {@code ENOLCK}
 	 */
-	int ernolck();
+	int enolck();
 
 	/**
 	 * Filename too long

--- a/jfuse-linux-aarch64/pom.xml
+++ b/jfuse-linux-aarch64/pom.xml
@@ -162,6 +162,8 @@
 										<includeMacro>ENOTSUP</includeMacro>
 										<includeMacro>EINVAL</includeMacro>
 										<includeMacro>ERANGE</includeMacro>
+										<includeMacro>ENOLCK</includeMacro>
+										<includeMacro>ENAMETOOLONG</includeMacro>
 									</includeMacros>
 								</configuration>
 							</execution>

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/LinuxErrno.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/LinuxErrno.java
@@ -76,7 +76,7 @@ record LinuxErrno() implements Errno {
 	}
 
 	@Override
-	public int ernolck() {
+	public int enolck() {
 		return errno_h.ENOLCK();
 	}
 

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/LinuxErrno.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/LinuxErrno.java
@@ -74,4 +74,14 @@ record LinuxErrno() implements Errno {
 	public int erange() {
 		return errno_h.ERANGE();
 	}
+
+	@Override
+	public int ernolck() {
+		return errno_h.ENOLCK();
+	}
+
+	@Override
+	public int enametoolong() {
+		return errno_h.ENAMETOOLONG();
+	}
 }

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/errno_h.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/errno_h.java
@@ -51,6 +51,12 @@ public class errno_h  {
     public static int ERANGE() {
         return (int)34L;
     }
+    public static int ENAMETOOLONG() {
+        return (int)36L;
+    }
+    public static int ENOLCK() {
+        return (int)37L;
+    }
     public static int ENOSYS() {
         return (int)38L;
     }

--- a/jfuse-linux-amd64/pom.xml
+++ b/jfuse-linux-amd64/pom.xml
@@ -162,6 +162,8 @@
 										<includeMacro>ENOTSUP</includeMacro>
 										<includeMacro>EINVAL</includeMacro>
 										<includeMacro>ERANGE</includeMacro>
+										<includeMacro>ENOLCK</includeMacro>
+										<includeMacro>ENAMETOOLONG</includeMacro>
 									</includeMacros>
 								</configuration>
 							</execution>

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/LinuxErrno.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/LinuxErrno.java
@@ -76,7 +76,7 @@ record LinuxErrno() implements Errno {
 	}
 
 	@Override
-	public int ernolck() {
+	public int enolck() {
 		return errno_h.ENOLCK();
 	}
 

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/LinuxErrno.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/LinuxErrno.java
@@ -74,4 +74,14 @@ record LinuxErrno() implements Errno {
 	public int erange() {
 		return errno_h.ERANGE();
 	}
+
+	@Override
+	public int ernolck() {
+		return errno_h.ENOLCK();
+	}
+
+	@Override
+	public int enametoolong() {
+		return errno_h.ENAMETOOLONG();
+	}
 }

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/errno_h.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/errno_h.java
@@ -51,6 +51,12 @@ public class errno_h  {
     public static int ERANGE() {
         return (int)34L;
     }
+    public static int ENAMETOOLONG() {
+        return (int)36L;
+    }
+    public static int ENOLCK() {
+        return (int)37L;
+    }
     public static int ENOSYS() {
         return (int)38L;
     }

--- a/jfuse-mac/pom.xml
+++ b/jfuse-mac/pom.xml
@@ -136,6 +136,8 @@
 										<includeMacro>ENOTSUP</includeMacro>
 										<includeMacro>EINVAL</includeMacro>
 										<includeMacro>ERANGE</includeMacro>
+										<includeMacro>ENOLCK</includeMacro>
+										<includeMacro>ENAMETOOLONG</includeMacro>
 									</includeMacros>
 								</configuration>
 							</execution>

--- a/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/MacErrno.java
+++ b/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/MacErrno.java
@@ -76,7 +76,7 @@ record MacErrno() implements Errno {
 	}
 
 	@Override
-	public int ernolck() {
+	public int enolck() {
 		return errno_h.ENOLCK();
 	}
 

--- a/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/MacErrno.java
+++ b/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/MacErrno.java
@@ -74,4 +74,14 @@ record MacErrno() implements Errno {
 	public int erange() {
 		return errno_h.ERANGE();
 	}
+
+	@Override
+	public int ernolck() {
+		return errno_h.ENOLCK();
+	}
+
+	@Override
+	public int enametoolong() {
+		return errno_h.ENAMETOOLONG();
+	}
 }

--- a/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/extr/errno_h.java
+++ b/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/extr/errno_h.java
@@ -54,8 +54,14 @@ public class errno_h  {
     public static int ENOTSUP() {
         return (int)45L;
     }
+    public static int ENAMETOOLONG() {
+        return (int)63L;
+    }
     public static int ENOTEMPTY() {
         return (int)66L;
+    }
+    public static int ENOLCK() {
+        return (int)77L;
     }
     public static int ENOSYS() {
         return (int)78L;

--- a/jfuse-win/pom.xml
+++ b/jfuse-win/pom.xml
@@ -156,6 +156,8 @@
 										<includeMacro>ENOTSUP</includeMacro>
 										<includeMacro>EINVAL</includeMacro>
 										<includeMacro>ERANGE</includeMacro>
+										<includeMacro>ENOLCK</includeMacro>
+										<includeMacro>ENAMETOOLONG</includeMacro>
 									</includeMacros>
 								</configuration>
 							</execution>

--- a/jfuse-win/src/main/java/org/cryptomator/jfuse/win/WinErrno.java
+++ b/jfuse-win/src/main/java/org/cryptomator/jfuse/win/WinErrno.java
@@ -76,7 +76,7 @@ record WinErrno() implements Errno {
 	}
 
 	@Override
-	public int ernolck() {
+	public int enolck() {
 		return errno_h.ENOLCK();
 	}
 

--- a/jfuse-win/src/main/java/org/cryptomator/jfuse/win/WinErrno.java
+++ b/jfuse-win/src/main/java/org/cryptomator/jfuse/win/WinErrno.java
@@ -74,4 +74,14 @@ record WinErrno() implements Errno {
 	public int erange() {
 		return errno_h.ERANGE();
 	}
+
+	@Override
+	public int ernolck() {
+		return errno_h.ENOLCK();
+	}
+
+	@Override
+	public int enametoolong() {
+		return errno_h.ENAMETOOLONG();
+	}
 }

--- a/jfuse-win/src/main/java/org/cryptomator/jfuse/win/extr/errno_h.java
+++ b/jfuse-win/src/main/java/org/cryptomator/jfuse/win/extr/errno_h.java
@@ -2,6 +2,10 @@
 
 package org.cryptomator.jfuse.win.extr;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+import java.lang.foreign.*;
 import static java.lang.foreign.ValueLayout.*;
 public class errno_h  {
 
@@ -41,8 +45,11 @@ public class errno_h  {
     public static int EROFS() {
         return (int)30L;
     }
-    public static int ERANGE() {
-        return (int)34L;
+    public static int ENAMETOOLONG() {
+        return (int)38L;
+    }
+    public static int ENOLCK() {
+        return (int)39L;
     }
     public static int ENOSYS() {
         return (int)40L;
@@ -50,11 +57,14 @@ public class errno_h  {
     public static int ENOTEMPTY() {
         return (int)41L;
     }
-    public static int ENOTSUP() {
-        return (int)129L;
-    }
     public static int EINVAL() {
         return (int)22L;
+    }
+    public static int ERANGE() {
+        return (int)34L;
+    }
+    public static int ENOTSUP() {
+        return (int)129L;
     }
 }
 


### PR DESCRIPTION
This PR adds the POSIX error codes ENLCK and ENAMETOOLONG to the Errno interface and implementations.

Reason is, that consumer librariers (i.e., fuse-nio-adapter) need those two for specific native fs pecularities.