### PR TITLE
allow up to unsigned int maximum when setting values in statvfs

### DIFF
--- a/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/StatvfsImpl.java
+++ b/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/StatvfsImpl.java
@@ -9,6 +9,8 @@ import java.lang.foreign.MemorySession;
 
 record StatvfsImpl(MemorySegment segment) implements Statvfs {
 
+	private static final long MAX_UINT = 0xFFFFFFFF;
+
 	public StatvfsImpl(MemoryAddress address, MemorySession scope) {
 		this(statvfs.ofAddress(address, scope));
 	}
@@ -40,8 +42,8 @@ record StatvfsImpl(MemorySegment segment) implements Statvfs {
 
 	@Override
 	public void setBlocks(long blocks) {
-		if (blocks > Integer.MAX_VALUE) {
-			throw new IllegalArgumentException("Max supported number of blocks: " + Integer.MAX_VALUE);
+		if (blocks > MAX_UINT){
+			throw new IllegalArgumentException("Max supported number of blocks: " + MAX_UINT);
 		} else {
 			statvfs.f_blocks$set(segment, (int) blocks);
 		}
@@ -54,8 +56,8 @@ record StatvfsImpl(MemorySegment segment) implements Statvfs {
 
 	@Override
 	public void setBfree(long bfree) {
-		if (bfree > Integer.MAX_VALUE) {
-			throw new IllegalArgumentException("Max supported number of blocks: " + Integer.MAX_VALUE);
+		if (bfree > MAX_UINT){
+			throw new IllegalArgumentException("Max supported number of blocks: " + MAX_UINT);
 		} else {
 			statvfs.f_bfree$set(segment, (int) bfree);
 		}
@@ -68,8 +70,8 @@ record StatvfsImpl(MemorySegment segment) implements Statvfs {
 
 	@Override
 	public void setBavail(long bavail) {
-		if (bavail > Integer.MAX_VALUE) {
-			throw new IllegalArgumentException("Max supported number of blocks: " + Integer.MAX_VALUE);
+		if (bavail > MAX_UINT){
+			throw new IllegalArgumentException("Max supported number of blocks: " + MAX_UINT);
 		} else {
 			statvfs.f_bavail$set(segment, (int) bavail);
 		}

--- a/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/StatvfsImpl.java
+++ b/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/StatvfsImpl.java
@@ -37,7 +37,7 @@ record StatvfsImpl(MemorySegment segment) implements Statvfs {
 
 	@Override
 	public long getBlocks() {
-		return statvfs.f_blocks$get(segment);
+		return Integer.toUnsignedLong(statvfs.f_blocks$get(segment));
 	}
 
 	@Override
@@ -51,7 +51,7 @@ record StatvfsImpl(MemorySegment segment) implements Statvfs {
 
 	@Override
 	public long getBfree() {
-		return statvfs.f_bfree$get(segment);
+		return Integer.toUnsignedLong(statvfs.f_bfree$get(segment));
 	}
 
 	@Override
@@ -65,7 +65,7 @@ record StatvfsImpl(MemorySegment segment) implements Statvfs {
 
 	@Override
 	public long getBavail() {
-		return statvfs.f_bavail$get(segment);
+		return Integer.toUnsignedLong(statvfs.f_bavail$get(segment));
 	}
 
 	@Override

--- a/jfuse-mac/src/test/java/org/cryptomator/jfuse/mac/StatvfsImplTest.java
+++ b/jfuse-mac/src/test/java/org/cryptomator/jfuse/mac/StatvfsImplTest.java
@@ -1,0 +1,123 @@
+package org.cryptomator.jfuse.mac;
+
+import org.cryptomator.jfuse.api.Statvfs;
+import org.cryptomator.jfuse.mac.extr.statvfs;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.MemorySession;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public class StatvfsImplTest {
+
+	@DisplayName("test getters")
+	@ParameterizedTest(name = "{1}")
+	@MethodSource
+	public void testGetters(SetInMemorySegment<Number> setter, GetInStatvfs<Number> getter, Number value) {
+		try (var scope = MemorySession.openConfined()) {
+			var segment = statvfs.allocate(scope);
+			var statvfs = new StatvfsImpl(segment.address(), scope);
+
+			setter.accept(segment, value);
+
+			Assertions.assertEquals(value.longValue(), getter.apply(statvfs).longValue());
+		}
+	}
+
+	public static Stream<Arguments> testGetters() {
+		return Stream.of(
+				Arguments.arguments((SetInMemorySegment<Long>) statvfs::f_bsize$set, Named.of("getBsize()", (GetInStatvfs<Long>) Statvfs::getBsize), 42L),
+				Arguments.arguments((SetInMemorySegment<Long>) statvfs::f_frsize$set, Named.of("getFrsize()", (GetInStatvfs<Long>) Statvfs::getFrsize), 42L),
+				Arguments.arguments((SetInMemorySegment<Integer>) statvfs::f_blocks$set, Named.of("getBlocks()", (GetInStatvfs<Long>) Statvfs::getBlocks), 42),
+				Arguments.arguments((SetInMemorySegment<Integer>) statvfs::f_bfree$set, Named.of("getBfree()", (GetInStatvfs<Long>) Statvfs::getBfree), 42),
+				Arguments.arguments((SetInMemorySegment<Integer>) statvfs::f_bavail$set, Named.of("getBavail()", (GetInStatvfs<Long>) Statvfs::getBavail), 42),
+				Arguments.arguments((SetInMemorySegment<Long>) statvfs::f_namemax$set, Named.of("getNameMax()", (GetInStatvfs<Long>) Statvfs::getNameMax), 42)
+		);
+	}
+
+	private interface SetInMemorySegment<T> extends BiConsumer<MemorySegment, T> {
+	}
+
+	private interface GetInStatvfs<T> extends Function<Statvfs, T> {
+	}
+
+	@DisplayName("test setters")
+	@ParameterizedTest(name = "{0}")
+	@MethodSource
+	public void testSetters(SetInStatvfs<Number> setter, GetInMemorySegment<Number> getter, Number value) {
+		try (var scope = MemorySession.openConfined()) {
+			var segment = statvfs.allocate(scope);
+			var statvfs = new StatvfsImpl(segment.address(), scope);
+
+			setter.accept(statvfs, value);
+
+			Assertions.assertEquals(value.longValue(), getter.apply(segment).longValue());
+		}
+	}
+
+	public static Stream<Arguments> testSetters() {
+		return Stream.of(
+				Arguments.arguments(Named.of("setBsize()", (SetInStatvfs<Long>) Statvfs::setBsize), (GetInMemorySegment<Long>) statvfs::f_bsize$get, 42L),
+				Arguments.arguments(Named.of("setFrsize()", (SetInStatvfs<Long>) Statvfs::setFrsize), (GetInMemorySegment<Long>) statvfs::f_frsize$get, 42L),
+				Arguments.arguments(Named.of("setBlocks()", (SetInStatvfs<Long>) Statvfs::setBlocks), (GetInMemorySegment<Integer>) statvfs::f_blocks$get, 42),
+				Arguments.arguments(Named.of("setBfree()", (SetInStatvfs<Long>) Statvfs::setBfree), (GetInMemorySegment<Integer>) statvfs::f_bfree$get, 42),
+				Arguments.arguments(Named.of("setBavail()", (SetInStatvfs<Long>) Statvfs::setBavail), (GetInMemorySegment<Integer>) statvfs::f_bavail$get, 42),
+				Arguments.arguments(Named.of("setNameMax()", (SetInStatvfs<Long>) Statvfs::setNameMax), (GetInMemorySegment<Long>) statvfs::f_namemax$get, 42L)
+		);
+	}
+
+	@DisplayName("test setters casting")
+	@ParameterizedTest(name = "{0}")
+	@MethodSource
+	public void testSettersCasting(SetInStatvfs<Number> setter, GetInMemorySegment<Number> getter, Number value) {
+		try (var scope = MemorySession.openConfined()) {
+			var segment = statvfs.allocate(scope);
+			var statvfs = new StatvfsImpl(segment.address(), scope);
+
+			setter.accept(statvfs, value);
+
+			Assertions.assertEquals(value.byteValue(), getter.apply(segment).byteValue());
+		}
+	}
+
+	public static Stream<Arguments> testSettersCasting() {
+		return Stream.of(
+				Arguments.arguments(Named.of("setBlocks()", (SetInStatvfs<Long>) Statvfs::setBlocks), (GetInMemorySegment<Integer>) statvfs::f_blocks$get, -42),
+				Arguments.arguments(Named.of("setBfree()", (SetInStatvfs<Long>) Statvfs::setBfree), (GetInMemorySegment<Integer>) statvfs::f_bfree$get, -42),
+				Arguments.arguments(Named.of("setBavail()", (SetInStatvfs<Long>) Statvfs::setBavail), (GetInMemorySegment<Integer>) statvfs::f_bavail$get, -42)
+		);
+	}
+
+	@DisplayName("test setters out-of-range")
+	@ParameterizedTest(name = "{0}")
+	@MethodSource
+	public void testSettersOutOfRange(SetInStatvfs<Number> setter, Number value) {
+		try (var scope = MemorySession.openConfined()) {
+			var segment = statvfs.allocate(scope);
+			var statvfs = new StatvfsImpl(segment.address(), scope);
+
+			Assertions.assertThrows(IllegalArgumentException.class, () -> setter.accept(statvfs, value));
+		}
+	}
+
+	public static Stream<Arguments> testSettersOutOfRange() {
+		return Stream.of(
+				Arguments.arguments(Named.of("setBlocks()", (SetInStatvfs<Long>) Statvfs::setBlocks), 0x100000000L),
+				Arguments.arguments(Named.of("setBfree()", (SetInStatvfs<Long>) Statvfs::setBfree), 0x100000000L),
+				Arguments.arguments(Named.of("setBavail()", (SetInStatvfs<Long>) Statvfs::setBavail), 0x100000000L)
+		);
+	}
+
+	private interface SetInStatvfs<T> extends BiConsumer<Statvfs, T> {
+	}
+
+	private interface GetInMemorySegment<T> extends Function<MemorySegment, T> {
+	}
+}


### PR DESCRIPTION
jfuse supports different operating systems and process architectures with a single API. Hence, if there are differences between systems/architectures, we have to choose the most generic one in the API and have to adapt to such differences in the API implementations. 

An example is the `Statvfs` interface with the method `void setBlocks(long blocks);`. As a parameter it accepts a long value. But on macOS actuall only values up to unsigned integers are supported, since the system structure `statvfs` has only this size:
```
/*
 * sys/statvfs.h
 */
#ifndef _SYS_STATVFS_H_
#define	_SYS_STATVFS_H_

#include <sys/_types.h>
#include <sys/cdefs.h>

#include <sys/_types/_fsblkcnt_t.h>
#include <sys/_types/_fsfilcnt_t.h>

/* Following structure is used as a statvfs/fstatvfs function parameter */
struct statvfs {
	unsigned long	f_bsize;	/* File system block size */
	unsigned long	f_frsize;	/* Fundamental file system block size */
	fsblkcnt_t	f_blocks;	/* Blocks on FS in units of f_frsize */
	fsblkcnt_t	f_bfree;	/* Free blocks */
	fsblkcnt_t	f_bavail;	/* Blocks available to non-root */
	fsfilcnt_t	f_files;	/* Total inodes */
	fsfilcnt_t	f_ffree;	/* Free inodes */
	fsfilcnt_t	f_favail;	/* Free inodes for non-root */
	unsigned long	f_fsid;		/* Filesystem ID */
	unsigned long	f_flag;		/* Bit mask of values */
	unsigned long	f_namemax;	/* Max file name length */
};
```

with `typedef unsigned int    __darwin_fsblkcnt_t;    /* Used by statvfs and fstatvfs */`.

Our current adaption allows values up to Java's `Integer.MAX_VALUE`:
https://github.com/cryptomator/jfuse/blob/7844848a5166d4aee9563314e6bcce01fb3cd270/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/StatvfsImpl.java#L41-L48

But since Java integers are signed, we are unnecessarily narrowing the allowed values to 2147483647, even thou an unsigned int can have values up to 4294967295. This PR changes the allowed values to the maximum range of unsigned integers.