### PR TITLE
add `ENOATTR` & `E2BIG`

### DIFF
--- a/jfuse-api/src/main/java/org/cryptomator/jfuse/api/Errno.java
+++ b/jfuse-api/src/main/java/org/cryptomator/jfuse/api/Errno.java
@@ -138,4 +138,11 @@ public interface Errno {
 	 */
 	int enoattr();
 
+	/**
+	 * Argument list too long
+	 *
+	 * @return error constant {@code E2BIG}
+	 */
+	int e2big();
+
 }

--- a/jfuse-api/src/main/java/org/cryptomator/jfuse/api/Errno.java
+++ b/jfuse-api/src/main/java/org/cryptomator/jfuse/api/Errno.java
@@ -131,4 +131,11 @@ public interface Errno {
 	 */
 	int enodata();
 
+	/**
+	 * The named attribute does not exist, or the process has no access to this attribute;
+	 *
+	 * @return error constant {@code ENOATTR}
+	 */
+	int enoattr();
+
 }

--- a/jfuse-linux-aarch64/pom.xml
+++ b/jfuse-linux-aarch64/pom.xml
@@ -166,6 +166,7 @@
 										<includeConstant>ENOLCK</includeConstant>
 										<includeConstant>ENAMETOOLONG</includeConstant>
 										<includeConstant>ENODATA</includeConstant>
+										<includeConstant>E2BIG</includeConstant>
 									</includeConstants>
 								</configuration>
 							</execution>

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/LinuxErrno.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/LinuxErrno.java
@@ -100,4 +100,9 @@ record LinuxErrno() implements Errno {
 	public int enoattr() {
 		return enodata();
 	}
+
+	@Override
+	public int e2big() {
+		return errno_h.E2BIG();
+	}
 }

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/LinuxErrno.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/LinuxErrno.java
@@ -89,4 +89,15 @@ record LinuxErrno() implements Errno {
 	public int enodata() {
 		return errno_h.ENODATA();
 	}
+
+	/**
+	 * Alias for {@link #enodata()}
+	 * @return error constant ENODATA
+	 * @deprecated Use {@link #enodata()} instead
+	 */
+	@Override
+	@Deprecated
+	public int enoattr() {
+		return enodata();
+	}
 }

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/errno/errno_h.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/errno/errno_h.java
@@ -35,6 +35,14 @@ public class errno_h  {
     }
     /**
      * {@snippet :
+     * #define E2BIG 7
+     * }
+     */
+    public static int E2BIG() {
+        return (int)7L;
+    }
+    /**
+     * {@snippet :
      * #define EBADF 9
      * }
      */

--- a/jfuse-linux-amd64/pom.xml
+++ b/jfuse-linux-amd64/pom.xml
@@ -166,6 +166,7 @@
 										<includeConstant>ENOLCK</includeConstant>
 										<includeConstant>ENAMETOOLONG</includeConstant>
 										<includeConstant>ENODATA</includeConstant>
+										<includeConstant>E2BIG</includeConstant>
 									</includeConstants>
 								</configuration>
 							</execution>

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/LinuxErrno.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/LinuxErrno.java
@@ -100,4 +100,9 @@ record LinuxErrno() implements Errno {
 	public int enoattr() {
 		return enodata();
 	}
+
+	@Override
+	public int e2big() {
+		return errno_h.E2BIG();
+	}
 }

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/LinuxErrno.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/LinuxErrno.java
@@ -89,4 +89,15 @@ record LinuxErrno() implements Errno {
 	public int enodata() {
 		return errno_h.ENODATA();
 	}
+
+	/**
+	 * Alias for {@link #enodata()}
+	 * @return error constant ENODATA
+	 * @deprecated Use {@link #enodata()} instead
+	 */
+	@Override
+	@Deprecated
+	public int enoattr() {
+		return enodata();
+	}
 }

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/errno/errno_h.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/errno/errno_h.java
@@ -35,6 +35,14 @@ public class errno_h  {
     }
     /**
      * {@snippet :
+     * #define E2BIG 7
+     * }
+     */
+    public static int E2BIG() {
+        return (int)7L;
+    }
+    /**
+     * {@snippet :
      * #define EBADF 9
      * }
      */

--- a/jfuse-mac/pom.xml
+++ b/jfuse-mac/pom.xml
@@ -140,6 +140,7 @@
 										<includeConstant>ENOLCK</includeConstant>
 										<includeConstant>ENAMETOOLONG</includeConstant>
 										<includeConstant>ENODATA</includeConstant>
+										<includeConstant>ENOATTR</includeConstant>
 									</includeConstants>
 								</configuration>
 							</execution>

--- a/jfuse-mac/pom.xml
+++ b/jfuse-mac/pom.xml
@@ -141,6 +141,7 @@
 										<includeConstant>ENAMETOOLONG</includeConstant>
 										<includeConstant>ENODATA</includeConstant>
 										<includeConstant>ENOATTR</includeConstant>
+										<includeConstant>E2BIG</includeConstant>
 									</includeConstants>
 								</configuration>
 							</execution>

--- a/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/MacErrno.java
+++ b/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/MacErrno.java
@@ -89,4 +89,9 @@ record MacErrno() implements Errno {
 	public int enodata() {
 		return errno_h.ENODATA();
 	}
+
+	@Override
+	public int enoattr() {
+		return errno_h.ENOATTR();
+	}
 }

--- a/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/MacErrno.java
+++ b/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/MacErrno.java
@@ -94,4 +94,9 @@ record MacErrno() implements Errno {
 	public int enoattr() {
 		return errno_h.ENOATTR();
 	}
+
+	@Override
+	public int e2big() {
+		return errno_h.E2BIG();
+	}
 }

--- a/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/extr/errno/errno_h.java
+++ b/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/extr/errno/errno_h.java
@@ -147,6 +147,14 @@ public class errno_h  {
     }
     /**
      * {@snippet :
+     * #define ENOATTR 93
+     * }
+     */
+    public static int ENOATTR() {
+        return (int)93L;
+    }
+    /**
+     * {@snippet :
      * #define ENODATA 96
      * }
      */

--- a/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/extr/errno/errno_h.java
+++ b/jfuse-mac/src/main/java/org/cryptomator/jfuse/mac/extr/errno/errno_h.java
@@ -35,6 +35,14 @@ public class errno_h  {
     }
     /**
      * {@snippet :
+     * #define E2BIG 7
+     * }
+     */
+    public static int E2BIG() {
+        return (int)7L;
+    }
+    /**
+     * {@snippet :
      * #define EBADF 9
      * }
      */

--- a/jfuse-win/pom.xml
+++ b/jfuse-win/pom.xml
@@ -166,6 +166,7 @@
 										<includeConstant>ENOLCK</includeConstant>
 										<includeConstant>ENAMETOOLONG</includeConstant>
 										<includeConstant>ENODATA</includeConstant>
+										<includeConstant>E2BIG</includeConstant>
 									</includeConstants>
 								</configuration>
 							</execution>

--- a/jfuse-win/src/main/java/org/cryptomator/jfuse/win/WinErrno.java
+++ b/jfuse-win/src/main/java/org/cryptomator/jfuse/win/WinErrno.java
@@ -100,4 +100,9 @@ record WinErrno() implements Errno {
 	public int enoattr() {
 		return enodata();
 	}
+
+	@Override
+	public int e2big() {
+		return errno_h.E2BIG();
+	}
 }

--- a/jfuse-win/src/main/java/org/cryptomator/jfuse/win/WinErrno.java
+++ b/jfuse-win/src/main/java/org/cryptomator/jfuse/win/WinErrno.java
@@ -89,4 +89,15 @@ record WinErrno() implements Errno {
 	public int enodata() {
 		return errno_h.ENODATA();
 	}
+
+	/**
+	 * Alias for {@link #enodata()}
+	 * @return error constant ENODATA
+	 * @deprecated Use {@link #enodata()} instead
+	 */
+	@Override
+	@Deprecated
+	public int enoattr() {
+		return enodata();
+	}
 }

--- a/jfuse-win/src/main/java/org/cryptomator/jfuse/win/extr/errno/errno_h.java
+++ b/jfuse-win/src/main/java/org/cryptomator/jfuse/win/extr/errno/errno_h.java
@@ -35,6 +35,14 @@ public class errno_h  {
     }
     /**
      * {@snippet :
+     * #define E2BIG 7
+     * }
+     */
+    public static int E2BIG() {
+        return (int)7L;
+    }
+    /**
+     * {@snippet :
      * #define EBADF 9
      * }
      */


### PR DESCRIPTION
Add two more error codes that may be relevant to correctly implement xattr.

`ENOATTR` is macOS-specific (BSD-specific, to be exact). On Linux, `ENODATA` is [commonly aliased by `ENOATTR`](https://github.com/search?q=repo%3Atorvalds%2Flinux%20ENOATTR&type=code), which is why this impl does the same. It is expected to be returned instead of `ENODATA` when a `getxattr` can not find the given attr.

`E2BIG` is expected to be returned by `setxattr`, when the given value is... too big.