### PR TITLE
Fallback to `System.loadLibrary(...)`

### DIFF
--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/LinuxFuseBuilder.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/LinuxFuseBuilder.java
@@ -14,7 +14,7 @@ import org.cryptomator.jfuse.api.platforms.SupportedPlatform;
 @SupportedPlatform(os = OperatingSystem.LINUX, arch = Architecture.ARM64)
 public class LinuxFuseBuilder implements FuseBuilder {
 
-	private static final String DEFAULT_LIB_PATH = "/lib/aarch64-linux-gnu/libfuse3.so.3";
+	private static final String DEFAULT_LIBNAME = "fuse3";
 	private static final Errno ERRNO = new LinuxErrno();
 	private String libraryPath;
 
@@ -39,7 +39,7 @@ public class LinuxFuseBuilder implements FuseBuilder {
 		if (libraryPath != null) {
 			System.load(libraryPath);
 		} else {
-			System.load(DEFAULT_LIB_PATH);
+			System.loadLibrary(DEFAULT_LIBNAME);
 		}
 		return new FuseImpl(fuseOperations);
 	}

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/LinuxFuseBuilder.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/LinuxFuseBuilder.java
@@ -14,7 +14,7 @@ import org.cryptomator.jfuse.api.platforms.SupportedPlatform;
 @SupportedPlatform(os = OperatingSystem.LINUX, arch = Architecture.AMD64)
 public class LinuxFuseBuilder implements FuseBuilder {
 
-	private static final String DEFAULT_LIB_PATH = "/lib/x86_64-linux-gnu/libfuse3.so.3";
+	private static final String DEFAULT_LIBNAME = "fuse3";
 	private static final Errno ERRNO = new LinuxErrno();
 	private String libraryPath;
 
@@ -39,7 +39,7 @@ public class LinuxFuseBuilder implements FuseBuilder {
 		if (libraryPath != null) {
 			System.load(libraryPath);
 		} else {
-			System.load(DEFAULT_LIB_PATH);
+			System.loadLibrary(DEFAULT_LIBNAME);
 		}
 		return new FuseImpl(fuseOperations);
 	}

--- a/jfuse-tests/pom.xml
+++ b/jfuse-tests/pom.xml
@@ -84,6 +84,7 @@
 					<argLine>@{surefire.jacoco.args} --enable-native-access=ALL-UNNAMED --enable-preview</argLine>
 					<systemProperties>
 						<fuse.lib.path>${fuse.lib.path}</fuse.lib.path>
+						<java.library.path>.:${java.library.path}</java.library.path>
 					</systemProperties>
 				</configuration>
 			</plugin>
@@ -103,6 +104,7 @@
 							<argLine>@{failsafe.jacoco.args} --enable-native-access=ALL-UNNAMED --enable-preview</argLine>
 							<systemProperties>
 								<fuse.lib.path>${fuse.lib.path}</fuse.lib.path>
+								<java.library.path>.:${java.library.path}</java.library.path>
 							</systemProperties>
 						</configuration>
 					</execution>

--- a/jfuse-tests/pom.xml
+++ b/jfuse-tests/pom.xml
@@ -81,11 +81,10 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
-					<argLine>@{surefire.jacoco.args} --enable-native-access=ALL-UNNAMED --enable-preview</argLine>
-					<systemProperties>
+					<argLine>@{surefire.jacoco.args} --enable-native-access=ALL-UNNAMED --enable-preview -Djava.library.path=".:${java.library.path}"</argLine>
+					<systemPropertyVariables>
 						<fuse.lib.path>${fuse.lib.path}</fuse.lib.path>
-						<java.library.path>.:${java.library.path}</java.library.path>
-					</systemProperties>
+					</systemPropertyVariables>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -101,11 +100,10 @@
 							<includes>
 								<include>**/*IT.java</include>
 							</includes>
-							<argLine>@{failsafe.jacoco.args} --enable-native-access=ALL-UNNAMED --enable-preview</argLine>
-							<systemProperties>
+							<argLine>@{failsafe.jacoco.args} --enable-native-access=ALL-UNNAMED --enable-preview -Djava.library.path=".:${java.library.path}"</argLine>
+							<systemPropertyVariables>
 								<fuse.lib.path>${fuse.lib.path}</fuse.lib.path>
-								<java.library.path>.:${java.library.path}</java.library.path>
-							</systemProperties>
+							</systemPropertyVariables>
 						</configuration>
 					</execution>
 				</executions>

--- a/jfuse-tests/src/test/java/org/cryptomator/jfuse/tests/FallbackLibLoadingIT.java
+++ b/jfuse-tests/src/test/java/org/cryptomator/jfuse/tests/FallbackLibLoadingIT.java
@@ -22,23 +22,21 @@ public class FallbackLibLoadingIT {
 	@Test
 	@EnabledOnOs(OS.LINUX)
 	@DisplayName("loads fuse lib from java.library.path, if not calling FuseBuilder.setLibraryPath(...)")
-	public void loadFromJavaLibraryPathOnLinux(@TempDir Path p) throws IOException, TimeoutException {
-		loadFromJavaLibraryPath(p, "libfuse3.so");
+	public void loadFromJavaLibraryPathOnLinux() throws IOException, TimeoutException {
+		loadFromJavaLibraryPath("libfuse3.so");
 	}
 
 	@Test
 	@EnabledOnOs(OS.MAC)
 	@DisplayName("loads fuse lib from java.library.path, if not calling FuseBuilder.setLibraryPath(...)")
-	public void loadFromJavaLibraryPathOnMacOS(@TempDir Path p) throws IOException, TimeoutException {
-		loadFromJavaLibraryPath(p, "libfuse-t.dylib");
+	public void loadFromJavaLibraryPathOnMacOS() throws IOException, TimeoutException {
+		loadFromJavaLibraryPath("libfuse-t.dylib");
 	}
 
-	private void loadFromJavaLibraryPath(Path tmpLibPath, String libFileName) throws IOException, TimeoutException {
-		var libPath = System.getProperty("fuse.lib.path");
-		var symlinkPath = tmpLibPath.resolve(libFileName);
-		Files.createSymbolicLink(symlinkPath, Path.of(libPath));
-
-		System.setProperty("java.library.path", tmpLibPath.toString());
+	private void loadFromJavaLibraryPath(String libFileName) throws IOException, TimeoutException {
+		// symlink ./${libName} -> ${fuse.lib.path}
+		var symlinkPath = Path.of(System.getProperty("user.dir"), libFileName);
+		Files.createSymbolicLink(symlinkPath, Path.of(System.getProperty("fuse.lib.path")));
 
 		var builder = Fuse.builder();
 		var fs = new RandomFileSystem(builder.errno());

--- a/jfuse-tests/src/test/java/org/cryptomator/jfuse/tests/FallbackLibLoadingIT.java
+++ b/jfuse-tests/src/test/java/org/cryptomator/jfuse/tests/FallbackLibLoadingIT.java
@@ -1,0 +1,49 @@
+package org.cryptomator.jfuse.tests;
+
+import org.cryptomator.jfuse.api.Fuse;
+import org.cryptomator.jfuse.examples.RandomFileSystem;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeoutException;
+
+@EnabledIfSystemProperty(named = "fuse.lib.path", matches = ".+")
+public class FallbackLibLoadingIT {
+
+	@Test
+	@EnabledOnOs(OS.LINUX)
+	@DisplayName("loads fuse lib from java.library.path, if not calling FuseBuilder.setLibraryPath(...)")
+	public void loadFromJavaLibraryPathOnLinux(@TempDir Path p) throws IOException, TimeoutException {
+		loadFromJavaLibraryPath(p, "libfuse3.so");
+	}
+
+	@Test
+	@EnabledOnOs(OS.MAC)
+	@DisplayName("loads fuse lib from java.library.path, if not calling FuseBuilder.setLibraryPath(...)")
+	public void loadFromJavaLibraryPathOnMacOS(@TempDir Path p) throws IOException, TimeoutException {
+		loadFromJavaLibraryPath(p, "libfuse-t.dylib");
+	}
+
+	private void loadFromJavaLibraryPath(Path tmpLibPath, String libFileName) throws IOException, TimeoutException {
+		var libPath = System.getProperty("fuse.lib.path");
+		var symlinkPath = tmpLibPath.resolve(libFileName);
+		Files.createSymbolicLink(symlinkPath, Path.of(libPath));
+
+		System.setProperty("java.library.path", tmpLibPath.toString());
+
+		var builder = Fuse.builder();
+		var fs = new RandomFileSystem(builder.errno());
+		var fuse = Assertions.assertDoesNotThrow(() -> builder.build(fs));
+		fuse.close();
+	}
+
+}


### PR DESCRIPTION
Use `System.loadLibrary("fuse3");` on Linux instead of Debian-specific `System.load("/lib/x86_64-linux-gnu/libfuse3.so.3")`, respecting `java.library.path`.

Similarly, try loading `fuse` or `fuse-t` on macOS.

This is still just a fallback. The primary attempt still depends on `builder.setLibraryPath(...)`, which is intended to be used by downstream projects, similar as in this example:

https://github.com/cryptomator/jfuse/blob/1c6064faa85a05f67cab4469c12850c07457386e/jfuse-tests/src/test/java/org/cryptomator/jfuse/tests/MirrorIT.java#L67-L70