### PR TITLE
update to `macos-latest` runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
 
   mac:
     name: Test jfuse-mac
-    runs-on: macos-12
+    runs-on: macos-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the GitHub Actions workflow to run on the latest macOS version.
	- Standardized artifact naming for coverage reports across platforms.
	- Improved job dependencies for SonarCloud analysis and release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->