### PR TITLE
Feature: Support libfuse version 3.17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
 
-  linux-amd64:
+  linux:
     name: Test jfuse-linux packages
     strategy:
       matrix:
@@ -31,7 +31,7 @@ jobs:
         run: mvn -B verify -Dfuse.lib.path="/lib/${{ matrix.arch }}-linux-gnu/libfuse3.so.3" --no-transfer-progress
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage-linux-${{ matrix.os }}
+          name: coverage-linux-${{ matrix.arch }}
           path: jfuse-tests/target/site/jacoco-aggregate/jacoco.xml
           retention-days: 3
 
@@ -81,7 +81,7 @@ jobs:
 
   sonarcloud:
     name: Run SonarCloud Analysis
-    needs: [linux-amd64, mac, win]
+    needs: [linux, mac, win]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -102,6 +102,10 @@ jobs:
         with:
           name: coverage-linux-amd64
           path: coverage/linux-amd64
+      - uses: actions/download-artifact@v4
+        with:
+          name: coverage-linux-aarch64
+          path: coverage/linux-aarch64
       - uses: actions/download-artifact@v4
         with:
           name: coverage-mac

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,15 @@ on:
 jobs:
 
   linux-amd64:
-    name: Test jfuse-linux-amd64
-    runs-on: ubuntu-latest
+    name: Test jfuse-linux packages
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+          - os: ubuntu-24.04-arm
+            arch: aarch64
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -21,10 +28,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install fuse3 libfuse3-dev
       - name: Maven build
-        run: mvn -B verify -Dfuse.lib.path="/lib/x86_64-linux-gnu/libfuse3.so.3" --no-transfer-progress
+        run: mvn -B verify -Dfuse.lib.path="/lib/${{ matrix.arch }}-linux-gnu/libfuse3.so.3" --no-transfer-progress
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage-linux-amd64
+          name: coverage-linux-${{ matrix.os }}
           path: jfuse-tests/target/site/jacoco-aggregate/jacoco.xml
           retention-days: 3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,8 +100,8 @@ jobs:
           restore-keys: ${{ runner.os }}-sonar
       - uses: actions/download-artifact@v4
         with:
-          name: coverage-linux-amd64
-          path: coverage/linux-amd64
+          name: coverage-linux-x86_64
+          path: coverage/linux-x86_64
       - uses: actions/download-artifact@v4
         with:
           name: coverage-linux-aarch64

--- a/jfuse-linux-aarch64/pom.xml
+++ b/jfuse-linux-aarch64/pom.xml
@@ -99,7 +99,7 @@
 									<headerClassName>fuse_h</headerClassName>
 									<cPreprocessorMacros>
 										<cPreprocessorMacro>_FILE_OFFSET_BITS=64</cPreprocessorMacro>
-										<cPreprocessorMacro>FUSE_USE_VERSION=312</cPreprocessorMacro>
+										<cPreprocessorMacro>FUSE_USE_VERSION=317</cPreprocessorMacro>
 									</cPreprocessorMacros>
 									<includeFunctions>
 										<includeFunction>fuse_version</includeFunction>
@@ -143,7 +143,7 @@
 									<headerClassName>fuse_lowlevel_h</headerClassName>
 									<cPreprocessorMacros>
 										<cPreprocessorMacro>_FILE_OFFSET_BITS=64</cPreprocessorMacro>
-										<cPreprocessorMacro>FUSE_USE_VERSION=312</cPreprocessorMacro>
+										<cPreprocessorMacro>FUSE_USE_VERSION=317</cPreprocessorMacro>
 									</cPreprocessorMacros>
 									<includeStructs>
 										<includeStruct>fuse_cmdline_opts</includeStruct>

--- a/jfuse-linux-aarch64/pom.xml
+++ b/jfuse-linux-aarch64/pom.xml
@@ -104,7 +104,6 @@
 									<includeFunctions>
 										<includeFunction>fuse_version</includeFunction>
 										<includeFunction>fuse_lib_help</includeFunction>
-										<includeFunction>fuse_new</includeFunction>
 										<includeFunction>fuse_mount</includeFunction>
 										<includeFunction>fuse_get_session</includeFunction>
 										<includeFunction>fuse_loop</includeFunction>

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/FuseFFIHelper.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/FuseFFIHelper.java
@@ -1,0 +1,73 @@
+package org.cryptomator.jfuse.linux.aarch64;
+
+import org.cryptomator.jfuse.linux.aarch64.extr.fuse3.fuse_h;
+
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.invoke.MethodHandle;
+
+/**
+ * Class for not jextract'able symbols, e.g. fuse_new_31
+ */
+public class FuseFFIHelper {
+
+
+	static final SymbolLookup SYMBOL_LOOKUP = SymbolLookup.loaderLookup()
+			.or(Linker.nativeLinker().defaultLookup());
+
+	static MemorySegment findOrThrow(String symbol) {
+		return SYMBOL_LOOKUP.find(symbol)
+				.orElseThrow(() -> new UnsatisfiedLinkError("unresolved symbol: " + symbol));
+	}
+
+	private static class fuse_new_31 {
+		public static final FunctionDescriptor DESC = FunctionDescriptor.of(
+				fuse_h.C_POINTER,
+				fuse_h.C_POINTER,
+				fuse_h.C_POINTER,
+				fuse_h.C_LONG,
+				fuse_h.C_POINTER
+		);
+
+		public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
+				findOrThrow("fuse_new_31"),
+				DESC);
+	}
+
+	/**
+	 * Function descriptor for:
+	 * {@snippet lang = c:
+	 * struct fuse *fuse_new(struct fuse_args *args, const struct fuse_operations *op, size_t op_size, void *private_data)
+	 *}
+	 */
+	public static FunctionDescriptor fuse_new_31$descriptor() {
+		return fuse_new_31.DESC;
+	}
+
+
+	/**
+	 * Downcall method handle for:
+	 * {@snippet lang = c:
+	 * struct fuse *fuse_new(struct fuse_args *args, const struct fuse_operations *op, size_t op_size, void *private_data)
+	 *}
+	 */
+	public static MethodHandle fuse_new_31$handle() {
+		return fuse_new_31.HANDLE;
+	}
+
+	/**
+	 * {@snippet lang = c:
+	 * struct fuse *fuse_new(struct fuse_args *args, const struct fuse_operations *op, size_t op_size, void *private_data)
+	 *}
+	 */
+	public static MemorySegment fuse_new_31(MemorySegment args, MemorySegment op, long op_size, MemorySegment private_data) {
+		var mh$ = fuse_new_31.HANDLE;
+		try {
+			return (MemorySegment) mh$.invokeExact(args, op, op_size, private_data);
+		} catch (Throwable ex$) {
+			throw new AssertionError("should not reach here", ex$);
+		}
+	}
+}

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/FuseImpl.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/FuseImpl.java
@@ -28,14 +28,20 @@ final class FuseImpl extends Fuse {
 	@Override
 	protected FuseMount mount(List<String> args) throws FuseMountFailedException {
 		var fuseArgs = parseArgs(args);
-		var fuse = fuse_h.fuse_new(fuseArgs.args(), fuseOperationsStruct, fuseOperationsStruct.byteSize(), MemorySegment.NULL);
-		if (MemorySegment.NULL.equals(fuse)) {
-			throw new FuseMountFailedException("fuse_new failed");
-		}
+		var fuse = createFuseFS(fuseArgs);
 		if (fuse_h.fuse_mount(fuse, fuseArgs.mountPoint()) != 0) {
 			throw new FuseMountFailedException("fuse_mount failed");
 		}
 		return new FuseMountImpl(fuse, fuseArgs);
+	}
+
+	@VisibleForTesting
+	MemorySegment createFuseFS(FuseArgs fuseArgs) throws FuseMountFailedException {
+		var fuse = FuseFFIHelper.fuse_new_31(fuseArgs.args(), fuseOperationsStruct, fuseOperationsStruct.byteSize(), MemorySegment.NULL);
+		if (MemorySegment.NULL.equals(fuse)) {
+			throw new FuseMountFailedException("fuse_new failed");
+		}
+		return fuse;
 	}
 
 	@VisibleForTesting

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/fuse3/fuse_args.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/fuse3/fuse_args.java
@@ -203,7 +203,7 @@ public class fuse_args {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -211,7 +211,7 @@ public class fuse_args {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/fuse3/fuse_config.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/fuse3/fuse_config.java
@@ -15,31 +15,36 @@ import static java.lang.foreign.MemoryLayout.PathElement.*;
 /**
  * {@snippet lang=c :
  * struct fuse_config {
- *     int set_gid;
- *     unsigned int gid;
- *     int set_uid;
- *     unsigned int uid;
- *     int set_mode;
- *     unsigned int umask;
+ *     int32_t set_gid;
+ *     uint32_t gid;
+ *     int32_t set_uid;
+ *     uint32_t uid;
+ *     int32_t set_mode;
+ *     uint32_t umask;
  *     double entry_timeout;
  *     double negative_timeout;
  *     double attr_timeout;
- *     int intr;
- *     int intr_signal;
- *     int remember;
- *     int hard_remove;
- *     int use_ino;
- *     int readdir_ino;
- *     int direct_io;
- *     int kernel_cache;
- *     int auto_cache;
- *     int no_rofd_flush;
- *     int ac_attr_timeout_set;
+ *     int32_t intr;
+ *     int32_t intr_signal;
+ *     int32_t remember;
+ *     int32_t hard_remove;
+ *     int32_t use_ino;
+ *     int32_t readdir_ino;
+ *     int32_t direct_io;
+ *     int32_t kernel_cache;
+ *     int32_t auto_cache;
+ *     int32_t ac_attr_timeout_set;
  *     double ac_attr_timeout;
- *     int nullpath_ok;
- *     int show_help;
+ *     int32_t nullpath_ok;
+ *     int32_t show_help;
  *     char *modules;
- *     int debug;
+ *     int32_t debug;
+ *     uint32_t fmask;
+ *     uint32_t dmask;
+ *     int32_t no_rofd_flush;
+ *     int32_t parallel_direct_writes;
+ *     uint32_t flags;
+ *     uint64_t reserved[48];
  * }
  * }
  */
@@ -68,15 +73,18 @@ public class fuse_config {
         fuse_h.C_INT.withName("direct_io"),
         fuse_h.C_INT.withName("kernel_cache"),
         fuse_h.C_INT.withName("auto_cache"),
-        fuse_h.C_INT.withName("no_rofd_flush"),
         fuse_h.C_INT.withName("ac_attr_timeout_set"),
-        MemoryLayout.paddingLayout(4),
         fuse_h.C_DOUBLE.withName("ac_attr_timeout"),
         fuse_h.C_INT.withName("nullpath_ok"),
         fuse_h.C_INT.withName("show_help"),
         fuse_h.C_POINTER.withName("modules"),
         fuse_h.C_INT.withName("debug"),
-        MemoryLayout.paddingLayout(4)
+        fuse_h.C_INT.withName("fmask"),
+        fuse_h.C_INT.withName("dmask"),
+        fuse_h.C_INT.withName("no_rofd_flush"),
+        fuse_h.C_INT.withName("parallel_direct_writes"),
+        fuse_h.C_INT.withName("flags"),
+        MemoryLayout.sequenceLayout(48, fuse_h.C_LONG).withName("reserved")
     ).withName("fuse_config");
 
     /**
@@ -91,7 +99,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int set_gid
+     * int32_t set_gid
      * }
      */
     public static final OfInt set_gid$layout() {
@@ -103,7 +111,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int set_gid
+     * int32_t set_gid
      * }
      */
     public static final long set_gid$offset() {
@@ -113,7 +121,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int set_gid
+     * int32_t set_gid
      * }
      */
     public static int set_gid(MemorySegment struct) {
@@ -123,7 +131,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int set_gid
+     * int32_t set_gid
      * }
      */
     public static void set_gid(MemorySegment struct, int fieldValue) {
@@ -135,7 +143,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int gid
+     * uint32_t gid
      * }
      */
     public static final OfInt gid$layout() {
@@ -147,7 +155,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int gid
+     * uint32_t gid
      * }
      */
     public static final long gid$offset() {
@@ -157,7 +165,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int gid
+     * uint32_t gid
      * }
      */
     public static int gid(MemorySegment struct) {
@@ -167,7 +175,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int gid
+     * uint32_t gid
      * }
      */
     public static void gid(MemorySegment struct, int fieldValue) {
@@ -179,7 +187,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int set_uid
+     * int32_t set_uid
      * }
      */
     public static final OfInt set_uid$layout() {
@@ -191,7 +199,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int set_uid
+     * int32_t set_uid
      * }
      */
     public static final long set_uid$offset() {
@@ -201,7 +209,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int set_uid
+     * int32_t set_uid
      * }
      */
     public static int set_uid(MemorySegment struct) {
@@ -211,7 +219,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int set_uid
+     * int32_t set_uid
      * }
      */
     public static void set_uid(MemorySegment struct, int fieldValue) {
@@ -223,7 +231,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int uid
+     * uint32_t uid
      * }
      */
     public static final OfInt uid$layout() {
@@ -235,7 +243,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int uid
+     * uint32_t uid
      * }
      */
     public static final long uid$offset() {
@@ -245,7 +253,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int uid
+     * uint32_t uid
      * }
      */
     public static int uid(MemorySegment struct) {
@@ -255,7 +263,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int uid
+     * uint32_t uid
      * }
      */
     public static void uid(MemorySegment struct, int fieldValue) {
@@ -267,7 +275,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int set_mode
+     * int32_t set_mode
      * }
      */
     public static final OfInt set_mode$layout() {
@@ -279,7 +287,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int set_mode
+     * int32_t set_mode
      * }
      */
     public static final long set_mode$offset() {
@@ -289,7 +297,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int set_mode
+     * int32_t set_mode
      * }
      */
     public static int set_mode(MemorySegment struct) {
@@ -299,7 +307,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int set_mode
+     * int32_t set_mode
      * }
      */
     public static void set_mode(MemorySegment struct, int fieldValue) {
@@ -311,7 +319,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int umask
+     * uint32_t umask
      * }
      */
     public static final OfInt umask$layout() {
@@ -323,7 +331,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int umask
+     * uint32_t umask
      * }
      */
     public static final long umask$offset() {
@@ -333,7 +341,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int umask
+     * uint32_t umask
      * }
      */
     public static int umask(MemorySegment struct) {
@@ -343,7 +351,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int umask
+     * uint32_t umask
      * }
      */
     public static void umask(MemorySegment struct, int fieldValue) {
@@ -487,7 +495,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int intr
+     * int32_t intr
      * }
      */
     public static final OfInt intr$layout() {
@@ -499,7 +507,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int intr
+     * int32_t intr
      * }
      */
     public static final long intr$offset() {
@@ -509,7 +517,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int intr
+     * int32_t intr
      * }
      */
     public static int intr(MemorySegment struct) {
@@ -519,7 +527,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int intr
+     * int32_t intr
      * }
      */
     public static void intr(MemorySegment struct, int fieldValue) {
@@ -531,7 +539,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int intr_signal
+     * int32_t intr_signal
      * }
      */
     public static final OfInt intr_signal$layout() {
@@ -543,7 +551,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int intr_signal
+     * int32_t intr_signal
      * }
      */
     public static final long intr_signal$offset() {
@@ -553,7 +561,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int intr_signal
+     * int32_t intr_signal
      * }
      */
     public static int intr_signal(MemorySegment struct) {
@@ -563,7 +571,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int intr_signal
+     * int32_t intr_signal
      * }
      */
     public static void intr_signal(MemorySegment struct, int fieldValue) {
@@ -575,7 +583,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int remember
+     * int32_t remember
      * }
      */
     public static final OfInt remember$layout() {
@@ -587,7 +595,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int remember
+     * int32_t remember
      * }
      */
     public static final long remember$offset() {
@@ -597,7 +605,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int remember
+     * int32_t remember
      * }
      */
     public static int remember(MemorySegment struct) {
@@ -607,7 +615,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int remember
+     * int32_t remember
      * }
      */
     public static void remember(MemorySegment struct, int fieldValue) {
@@ -619,7 +627,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int hard_remove
+     * int32_t hard_remove
      * }
      */
     public static final OfInt hard_remove$layout() {
@@ -631,7 +639,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int hard_remove
+     * int32_t hard_remove
      * }
      */
     public static final long hard_remove$offset() {
@@ -641,7 +649,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int hard_remove
+     * int32_t hard_remove
      * }
      */
     public static int hard_remove(MemorySegment struct) {
@@ -651,7 +659,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int hard_remove
+     * int32_t hard_remove
      * }
      */
     public static void hard_remove(MemorySegment struct, int fieldValue) {
@@ -663,7 +671,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int use_ino
+     * int32_t use_ino
      * }
      */
     public static final OfInt use_ino$layout() {
@@ -675,7 +683,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int use_ino
+     * int32_t use_ino
      * }
      */
     public static final long use_ino$offset() {
@@ -685,7 +693,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int use_ino
+     * int32_t use_ino
      * }
      */
     public static int use_ino(MemorySegment struct) {
@@ -695,7 +703,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int use_ino
+     * int32_t use_ino
      * }
      */
     public static void use_ino(MemorySegment struct, int fieldValue) {
@@ -707,7 +715,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int readdir_ino
+     * int32_t readdir_ino
      * }
      */
     public static final OfInt readdir_ino$layout() {
@@ -719,7 +727,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int readdir_ino
+     * int32_t readdir_ino
      * }
      */
     public static final long readdir_ino$offset() {
@@ -729,7 +737,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int readdir_ino
+     * int32_t readdir_ino
      * }
      */
     public static int readdir_ino(MemorySegment struct) {
@@ -739,7 +747,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int readdir_ino
+     * int32_t readdir_ino
      * }
      */
     public static void readdir_ino(MemorySegment struct, int fieldValue) {
@@ -751,7 +759,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int direct_io
+     * int32_t direct_io
      * }
      */
     public static final OfInt direct_io$layout() {
@@ -763,7 +771,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int direct_io
+     * int32_t direct_io
      * }
      */
     public static final long direct_io$offset() {
@@ -773,7 +781,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int direct_io
+     * int32_t direct_io
      * }
      */
     public static int direct_io(MemorySegment struct) {
@@ -783,7 +791,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int direct_io
+     * int32_t direct_io
      * }
      */
     public static void direct_io(MemorySegment struct, int fieldValue) {
@@ -795,7 +803,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int kernel_cache
+     * int32_t kernel_cache
      * }
      */
     public static final OfInt kernel_cache$layout() {
@@ -807,7 +815,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int kernel_cache
+     * int32_t kernel_cache
      * }
      */
     public static final long kernel_cache$offset() {
@@ -817,7 +825,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int kernel_cache
+     * int32_t kernel_cache
      * }
      */
     public static int kernel_cache(MemorySegment struct) {
@@ -827,7 +835,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int kernel_cache
+     * int32_t kernel_cache
      * }
      */
     public static void kernel_cache(MemorySegment struct, int fieldValue) {
@@ -839,7 +847,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int auto_cache
+     * int32_t auto_cache
      * }
      */
     public static final OfInt auto_cache$layout() {
@@ -851,7 +859,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int auto_cache
+     * int32_t auto_cache
      * }
      */
     public static final long auto_cache$offset() {
@@ -861,7 +869,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int auto_cache
+     * int32_t auto_cache
      * }
      */
     public static int auto_cache(MemorySegment struct) {
@@ -871,55 +879,11 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int auto_cache
+     * int32_t auto_cache
      * }
      */
     public static void auto_cache(MemorySegment struct, int fieldValue) {
         struct.set(auto_cache$LAYOUT, auto_cache$OFFSET, fieldValue);
-    }
-
-    private static final OfInt no_rofd_flush$LAYOUT = (OfInt)$LAYOUT.select(groupElement("no_rofd_flush"));
-
-    /**
-     * Layout for field:
-     * {@snippet lang=c :
-     * int no_rofd_flush
-     * }
-     */
-    public static final OfInt no_rofd_flush$layout() {
-        return no_rofd_flush$LAYOUT;
-    }
-
-    private static final long no_rofd_flush$OFFSET = 84;
-
-    /**
-     * Offset for field:
-     * {@snippet lang=c :
-     * int no_rofd_flush
-     * }
-     */
-    public static final long no_rofd_flush$offset() {
-        return no_rofd_flush$OFFSET;
-    }
-
-    /**
-     * Getter for field:
-     * {@snippet lang=c :
-     * int no_rofd_flush
-     * }
-     */
-    public static int no_rofd_flush(MemorySegment struct) {
-        return struct.get(no_rofd_flush$LAYOUT, no_rofd_flush$OFFSET);
-    }
-
-    /**
-     * Setter for field:
-     * {@snippet lang=c :
-     * int no_rofd_flush
-     * }
-     */
-    public static void no_rofd_flush(MemorySegment struct, int fieldValue) {
-        struct.set(no_rofd_flush$LAYOUT, no_rofd_flush$OFFSET, fieldValue);
     }
 
     private static final OfInt ac_attr_timeout_set$LAYOUT = (OfInt)$LAYOUT.select(groupElement("ac_attr_timeout_set"));
@@ -927,19 +891,19 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int ac_attr_timeout_set
+     * int32_t ac_attr_timeout_set
      * }
      */
     public static final OfInt ac_attr_timeout_set$layout() {
         return ac_attr_timeout_set$LAYOUT;
     }
 
-    private static final long ac_attr_timeout_set$OFFSET = 88;
+    private static final long ac_attr_timeout_set$OFFSET = 84;
 
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int ac_attr_timeout_set
+     * int32_t ac_attr_timeout_set
      * }
      */
     public static final long ac_attr_timeout_set$offset() {
@@ -949,7 +913,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int ac_attr_timeout_set
+     * int32_t ac_attr_timeout_set
      * }
      */
     public static int ac_attr_timeout_set(MemorySegment struct) {
@@ -959,7 +923,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int ac_attr_timeout_set
+     * int32_t ac_attr_timeout_set
      * }
      */
     public static void ac_attr_timeout_set(MemorySegment struct, int fieldValue) {
@@ -978,7 +942,7 @@ public class fuse_config {
         return ac_attr_timeout$LAYOUT;
     }
 
-    private static final long ac_attr_timeout$OFFSET = 96;
+    private static final long ac_attr_timeout$OFFSET = 88;
 
     /**
      * Offset for field:
@@ -1015,19 +979,19 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int nullpath_ok
+     * int32_t nullpath_ok
      * }
      */
     public static final OfInt nullpath_ok$layout() {
         return nullpath_ok$LAYOUT;
     }
 
-    private static final long nullpath_ok$OFFSET = 104;
+    private static final long nullpath_ok$OFFSET = 96;
 
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int nullpath_ok
+     * int32_t nullpath_ok
      * }
      */
     public static final long nullpath_ok$offset() {
@@ -1037,7 +1001,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int nullpath_ok
+     * int32_t nullpath_ok
      * }
      */
     public static int nullpath_ok(MemorySegment struct) {
@@ -1047,7 +1011,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int nullpath_ok
+     * int32_t nullpath_ok
      * }
      */
     public static void nullpath_ok(MemorySegment struct, int fieldValue) {
@@ -1059,19 +1023,19 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int show_help
+     * int32_t show_help
      * }
      */
     public static final OfInt show_help$layout() {
         return show_help$LAYOUT;
     }
 
-    private static final long show_help$OFFSET = 108;
+    private static final long show_help$OFFSET = 100;
 
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int show_help
+     * int32_t show_help
      * }
      */
     public static final long show_help$offset() {
@@ -1081,7 +1045,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int show_help
+     * int32_t show_help
      * }
      */
     public static int show_help(MemorySegment struct) {
@@ -1091,7 +1055,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int show_help
+     * int32_t show_help
      * }
      */
     public static void show_help(MemorySegment struct, int fieldValue) {
@@ -1110,7 +1074,7 @@ public class fuse_config {
         return modules$LAYOUT;
     }
 
-    private static final long modules$OFFSET = 112;
+    private static final long modules$OFFSET = 104;
 
     /**
      * Offset for field:
@@ -1147,19 +1111,19 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int debug
+     * int32_t debug
      * }
      */
     public static final OfInt debug$layout() {
         return debug$LAYOUT;
     }
 
-    private static final long debug$OFFSET = 120;
+    private static final long debug$OFFSET = 112;
 
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int debug
+     * int32_t debug
      * }
      */
     public static final long debug$offset() {
@@ -1169,7 +1133,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int debug
+     * int32_t debug
      * }
      */
     public static int debug(MemorySegment struct) {
@@ -1179,11 +1143,308 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int debug
+     * int32_t debug
      * }
      */
     public static void debug(MemorySegment struct, int fieldValue) {
         struct.set(debug$LAYOUT, debug$OFFSET, fieldValue);
+    }
+
+    private static final OfInt fmask$LAYOUT = (OfInt)$LAYOUT.select(groupElement("fmask"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * uint32_t fmask
+     * }
+     */
+    public static final OfInt fmask$layout() {
+        return fmask$LAYOUT;
+    }
+
+    private static final long fmask$OFFSET = 116;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * uint32_t fmask
+     * }
+     */
+    public static final long fmask$offset() {
+        return fmask$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * uint32_t fmask
+     * }
+     */
+    public static int fmask(MemorySegment struct) {
+        return struct.get(fmask$LAYOUT, fmask$OFFSET);
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * uint32_t fmask
+     * }
+     */
+    public static void fmask(MemorySegment struct, int fieldValue) {
+        struct.set(fmask$LAYOUT, fmask$OFFSET, fieldValue);
+    }
+
+    private static final OfInt dmask$LAYOUT = (OfInt)$LAYOUT.select(groupElement("dmask"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * uint32_t dmask
+     * }
+     */
+    public static final OfInt dmask$layout() {
+        return dmask$LAYOUT;
+    }
+
+    private static final long dmask$OFFSET = 120;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * uint32_t dmask
+     * }
+     */
+    public static final long dmask$offset() {
+        return dmask$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * uint32_t dmask
+     * }
+     */
+    public static int dmask(MemorySegment struct) {
+        return struct.get(dmask$LAYOUT, dmask$OFFSET);
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * uint32_t dmask
+     * }
+     */
+    public static void dmask(MemorySegment struct, int fieldValue) {
+        struct.set(dmask$LAYOUT, dmask$OFFSET, fieldValue);
+    }
+
+    private static final OfInt no_rofd_flush$LAYOUT = (OfInt)$LAYOUT.select(groupElement("no_rofd_flush"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * int32_t no_rofd_flush
+     * }
+     */
+    public static final OfInt no_rofd_flush$layout() {
+        return no_rofd_flush$LAYOUT;
+    }
+
+    private static final long no_rofd_flush$OFFSET = 124;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * int32_t no_rofd_flush
+     * }
+     */
+    public static final long no_rofd_flush$offset() {
+        return no_rofd_flush$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * int32_t no_rofd_flush
+     * }
+     */
+    public static int no_rofd_flush(MemorySegment struct) {
+        return struct.get(no_rofd_flush$LAYOUT, no_rofd_flush$OFFSET);
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * int32_t no_rofd_flush
+     * }
+     */
+    public static void no_rofd_flush(MemorySegment struct, int fieldValue) {
+        struct.set(no_rofd_flush$LAYOUT, no_rofd_flush$OFFSET, fieldValue);
+    }
+
+    private static final OfInt parallel_direct_writes$LAYOUT = (OfInt)$LAYOUT.select(groupElement("parallel_direct_writes"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * int32_t parallel_direct_writes
+     * }
+     */
+    public static final OfInt parallel_direct_writes$layout() {
+        return parallel_direct_writes$LAYOUT;
+    }
+
+    private static final long parallel_direct_writes$OFFSET = 128;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * int32_t parallel_direct_writes
+     * }
+     */
+    public static final long parallel_direct_writes$offset() {
+        return parallel_direct_writes$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * int32_t parallel_direct_writes
+     * }
+     */
+    public static int parallel_direct_writes(MemorySegment struct) {
+        return struct.get(parallel_direct_writes$LAYOUT, parallel_direct_writes$OFFSET);
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * int32_t parallel_direct_writes
+     * }
+     */
+    public static void parallel_direct_writes(MemorySegment struct, int fieldValue) {
+        struct.set(parallel_direct_writes$LAYOUT, parallel_direct_writes$OFFSET, fieldValue);
+    }
+
+    private static final OfInt flags$LAYOUT = (OfInt)$LAYOUT.select(groupElement("flags"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * uint32_t flags
+     * }
+     */
+    public static final OfInt flags$layout() {
+        return flags$LAYOUT;
+    }
+
+    private static final long flags$OFFSET = 132;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * uint32_t flags
+     * }
+     */
+    public static final long flags$offset() {
+        return flags$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * uint32_t flags
+     * }
+     */
+    public static int flags(MemorySegment struct) {
+        return struct.get(flags$LAYOUT, flags$OFFSET);
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * uint32_t flags
+     * }
+     */
+    public static void flags(MemorySegment struct, int fieldValue) {
+        struct.set(flags$LAYOUT, flags$OFFSET, fieldValue);
+    }
+
+    private static final SequenceLayout reserved$LAYOUT = (SequenceLayout)$LAYOUT.select(groupElement("reserved"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * uint64_t reserved[48]
+     * }
+     */
+    public static final SequenceLayout reserved$layout() {
+        return reserved$LAYOUT;
+    }
+
+    private static final long reserved$OFFSET = 136;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * uint64_t reserved[48]
+     * }
+     */
+    public static final long reserved$offset() {
+        return reserved$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * uint64_t reserved[48]
+     * }
+     */
+    public static MemorySegment reserved(MemorySegment struct) {
+        return struct.asSlice(reserved$OFFSET, reserved$LAYOUT.byteSize());
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * uint64_t reserved[48]
+     * }
+     */
+    public static void reserved(MemorySegment struct, MemorySegment fieldValue) {
+        MemorySegment.copy(fieldValue, 0L, struct, reserved$OFFSET, reserved$LAYOUT.byteSize());
+    }
+
+    private static long[] reserved$DIMS = { 48 };
+
+    /**
+     * Dimensions for array field:
+     * {@snippet lang=c :
+     * uint64_t reserved[48]
+     * }
+     */
+    public static long[] reserved$dimensions() {
+        return reserved$DIMS;
+    }
+    private static final VarHandle reserved$ELEM_HANDLE = reserved$LAYOUT.varHandle(sequenceElement());
+
+    /**
+     * Indexed getter for field:
+     * {@snippet lang=c :
+     * uint64_t reserved[48]
+     * }
+     */
+    public static long reserved(MemorySegment struct, long index0) {
+        return (long)reserved$ELEM_HANDLE.get(struct, 0L, index0);
+    }
+
+    /**
+     * Indexed setter for field:
+     * {@snippet lang=c :
+     * uint64_t reserved[48]
+     * }
+     */
+    public static void reserved(MemorySegment struct, long index0, long fieldValue) {
+        reserved$ELEM_HANDLE.set(struct, 0L, index0, fieldValue);
     }
 
     /**
@@ -1215,7 +1476,7 @@ public class fuse_config {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -1223,7 +1484,7 @@ public class fuse_config {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/fuse3/fuse_conn_info.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/fuse3/fuse_conn_info.java
@@ -15,17 +15,22 @@ import static java.lang.foreign.MemoryLayout.PathElement.*;
 /**
  * {@snippet lang=c :
  * struct fuse_conn_info {
- *     unsigned int proto_major;
- *     unsigned int proto_minor;
- *     unsigned int max_write;
- *     unsigned int max_read;
- *     unsigned int max_readahead;
- *     unsigned int capable;
- *     unsigned int want;
- *     unsigned int max_background;
- *     unsigned int congestion_threshold;
- *     unsigned int time_gran;
- *     unsigned int reserved[22];
+ *     uint32_t proto_major;
+ *     uint32_t proto_minor;
+ *     uint32_t max_write;
+ *     uint32_t max_read;
+ *     uint32_t max_readahead;
+ *     uint32_t capable;
+ *     uint32_t want;
+ *     uint32_t max_background;
+ *     uint32_t congestion_threshold;
+ *     uint32_t time_gran;
+ *     uint32_t max_backing_stack_depth;
+ *     uint32_t no_interrupt : 1;
+ *     uint32_t padding : 31;
+ *     uint64_t capable_ext;
+ *     uint64_t want_ext;
+ *     uint32_t reserved[16];
  * }
  * }
  */
@@ -46,7 +51,11 @@ public class fuse_conn_info {
         fuse_h.C_INT.withName("max_background"),
         fuse_h.C_INT.withName("congestion_threshold"),
         fuse_h.C_INT.withName("time_gran"),
-        MemoryLayout.sequenceLayout(22, fuse_h.C_INT).withName("reserved")
+        fuse_h.C_INT.withName("max_backing_stack_depth"),
+        MemoryLayout.paddingLayout(4),
+        fuse_h.C_LONG.withName("capable_ext"),
+        fuse_h.C_LONG.withName("want_ext"),
+        MemoryLayout.sequenceLayout(16, fuse_h.C_INT).withName("reserved")
     ).withName("fuse_conn_info");
 
     /**
@@ -61,7 +70,7 @@ public class fuse_conn_info {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int proto_major
+     * uint32_t proto_major
      * }
      */
     public static final OfInt proto_major$layout() {
@@ -73,7 +82,7 @@ public class fuse_conn_info {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int proto_major
+     * uint32_t proto_major
      * }
      */
     public static final long proto_major$offset() {
@@ -83,7 +92,7 @@ public class fuse_conn_info {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int proto_major
+     * uint32_t proto_major
      * }
      */
     public static int proto_major(MemorySegment struct) {
@@ -93,7 +102,7 @@ public class fuse_conn_info {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int proto_major
+     * uint32_t proto_major
      * }
      */
     public static void proto_major(MemorySegment struct, int fieldValue) {
@@ -105,7 +114,7 @@ public class fuse_conn_info {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int proto_minor
+     * uint32_t proto_minor
      * }
      */
     public static final OfInt proto_minor$layout() {
@@ -117,7 +126,7 @@ public class fuse_conn_info {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int proto_minor
+     * uint32_t proto_minor
      * }
      */
     public static final long proto_minor$offset() {
@@ -127,7 +136,7 @@ public class fuse_conn_info {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int proto_minor
+     * uint32_t proto_minor
      * }
      */
     public static int proto_minor(MemorySegment struct) {
@@ -137,7 +146,7 @@ public class fuse_conn_info {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int proto_minor
+     * uint32_t proto_minor
      * }
      */
     public static void proto_minor(MemorySegment struct, int fieldValue) {
@@ -149,7 +158,7 @@ public class fuse_conn_info {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int max_write
+     * uint32_t max_write
      * }
      */
     public static final OfInt max_write$layout() {
@@ -161,7 +170,7 @@ public class fuse_conn_info {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int max_write
+     * uint32_t max_write
      * }
      */
     public static final long max_write$offset() {
@@ -171,7 +180,7 @@ public class fuse_conn_info {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int max_write
+     * uint32_t max_write
      * }
      */
     public static int max_write(MemorySegment struct) {
@@ -181,7 +190,7 @@ public class fuse_conn_info {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int max_write
+     * uint32_t max_write
      * }
      */
     public static void max_write(MemorySegment struct, int fieldValue) {
@@ -193,7 +202,7 @@ public class fuse_conn_info {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int max_read
+     * uint32_t max_read
      * }
      */
     public static final OfInt max_read$layout() {
@@ -205,7 +214,7 @@ public class fuse_conn_info {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int max_read
+     * uint32_t max_read
      * }
      */
     public static final long max_read$offset() {
@@ -215,7 +224,7 @@ public class fuse_conn_info {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int max_read
+     * uint32_t max_read
      * }
      */
     public static int max_read(MemorySegment struct) {
@@ -225,7 +234,7 @@ public class fuse_conn_info {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int max_read
+     * uint32_t max_read
      * }
      */
     public static void max_read(MemorySegment struct, int fieldValue) {
@@ -237,7 +246,7 @@ public class fuse_conn_info {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int max_readahead
+     * uint32_t max_readahead
      * }
      */
     public static final OfInt max_readahead$layout() {
@@ -249,7 +258,7 @@ public class fuse_conn_info {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int max_readahead
+     * uint32_t max_readahead
      * }
      */
     public static final long max_readahead$offset() {
@@ -259,7 +268,7 @@ public class fuse_conn_info {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int max_readahead
+     * uint32_t max_readahead
      * }
      */
     public static int max_readahead(MemorySegment struct) {
@@ -269,7 +278,7 @@ public class fuse_conn_info {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int max_readahead
+     * uint32_t max_readahead
      * }
      */
     public static void max_readahead(MemorySegment struct, int fieldValue) {
@@ -281,7 +290,7 @@ public class fuse_conn_info {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int capable
+     * uint32_t capable
      * }
      */
     public static final OfInt capable$layout() {
@@ -293,7 +302,7 @@ public class fuse_conn_info {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int capable
+     * uint32_t capable
      * }
      */
     public static final long capable$offset() {
@@ -303,7 +312,7 @@ public class fuse_conn_info {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int capable
+     * uint32_t capable
      * }
      */
     public static int capable(MemorySegment struct) {
@@ -313,7 +322,7 @@ public class fuse_conn_info {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int capable
+     * uint32_t capable
      * }
      */
     public static void capable(MemorySegment struct, int fieldValue) {
@@ -325,7 +334,7 @@ public class fuse_conn_info {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int want
+     * uint32_t want
      * }
      */
     public static final OfInt want$layout() {
@@ -337,7 +346,7 @@ public class fuse_conn_info {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int want
+     * uint32_t want
      * }
      */
     public static final long want$offset() {
@@ -347,7 +356,7 @@ public class fuse_conn_info {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int want
+     * uint32_t want
      * }
      */
     public static int want(MemorySegment struct) {
@@ -357,7 +366,7 @@ public class fuse_conn_info {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int want
+     * uint32_t want
      * }
      */
     public static void want(MemorySegment struct, int fieldValue) {
@@ -369,7 +378,7 @@ public class fuse_conn_info {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int max_background
+     * uint32_t max_background
      * }
      */
     public static final OfInt max_background$layout() {
@@ -381,7 +390,7 @@ public class fuse_conn_info {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int max_background
+     * uint32_t max_background
      * }
      */
     public static final long max_background$offset() {
@@ -391,7 +400,7 @@ public class fuse_conn_info {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int max_background
+     * uint32_t max_background
      * }
      */
     public static int max_background(MemorySegment struct) {
@@ -401,7 +410,7 @@ public class fuse_conn_info {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int max_background
+     * uint32_t max_background
      * }
      */
     public static void max_background(MemorySegment struct, int fieldValue) {
@@ -413,7 +422,7 @@ public class fuse_conn_info {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int congestion_threshold
+     * uint32_t congestion_threshold
      * }
      */
     public static final OfInt congestion_threshold$layout() {
@@ -425,7 +434,7 @@ public class fuse_conn_info {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int congestion_threshold
+     * uint32_t congestion_threshold
      * }
      */
     public static final long congestion_threshold$offset() {
@@ -435,7 +444,7 @@ public class fuse_conn_info {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int congestion_threshold
+     * uint32_t congestion_threshold
      * }
      */
     public static int congestion_threshold(MemorySegment struct) {
@@ -445,7 +454,7 @@ public class fuse_conn_info {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int congestion_threshold
+     * uint32_t congestion_threshold
      * }
      */
     public static void congestion_threshold(MemorySegment struct, int fieldValue) {
@@ -457,7 +466,7 @@ public class fuse_conn_info {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int time_gran
+     * uint32_t time_gran
      * }
      */
     public static final OfInt time_gran$layout() {
@@ -469,7 +478,7 @@ public class fuse_conn_info {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int time_gran
+     * uint32_t time_gran
      * }
      */
     public static final long time_gran$offset() {
@@ -479,7 +488,7 @@ public class fuse_conn_info {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int time_gran
+     * uint32_t time_gran
      * }
      */
     public static int time_gran(MemorySegment struct) {
@@ -489,11 +498,143 @@ public class fuse_conn_info {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int time_gran
+     * uint32_t time_gran
      * }
      */
     public static void time_gran(MemorySegment struct, int fieldValue) {
         struct.set(time_gran$LAYOUT, time_gran$OFFSET, fieldValue);
+    }
+
+    private static final OfInt max_backing_stack_depth$LAYOUT = (OfInt)$LAYOUT.select(groupElement("max_backing_stack_depth"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * uint32_t max_backing_stack_depth
+     * }
+     */
+    public static final OfInt max_backing_stack_depth$layout() {
+        return max_backing_stack_depth$LAYOUT;
+    }
+
+    private static final long max_backing_stack_depth$OFFSET = 40;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * uint32_t max_backing_stack_depth
+     * }
+     */
+    public static final long max_backing_stack_depth$offset() {
+        return max_backing_stack_depth$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * uint32_t max_backing_stack_depth
+     * }
+     */
+    public static int max_backing_stack_depth(MemorySegment struct) {
+        return struct.get(max_backing_stack_depth$LAYOUT, max_backing_stack_depth$OFFSET);
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * uint32_t max_backing_stack_depth
+     * }
+     */
+    public static void max_backing_stack_depth(MemorySegment struct, int fieldValue) {
+        struct.set(max_backing_stack_depth$LAYOUT, max_backing_stack_depth$OFFSET, fieldValue);
+    }
+
+    private static final OfLong capable_ext$LAYOUT = (OfLong)$LAYOUT.select(groupElement("capable_ext"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * uint64_t capable_ext
+     * }
+     */
+    public static final OfLong capable_ext$layout() {
+        return capable_ext$LAYOUT;
+    }
+
+    private static final long capable_ext$OFFSET = 48;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * uint64_t capable_ext
+     * }
+     */
+    public static final long capable_ext$offset() {
+        return capable_ext$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * uint64_t capable_ext
+     * }
+     */
+    public static long capable_ext(MemorySegment struct) {
+        return struct.get(capable_ext$LAYOUT, capable_ext$OFFSET);
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * uint64_t capable_ext
+     * }
+     */
+    public static void capable_ext(MemorySegment struct, long fieldValue) {
+        struct.set(capable_ext$LAYOUT, capable_ext$OFFSET, fieldValue);
+    }
+
+    private static final OfLong want_ext$LAYOUT = (OfLong)$LAYOUT.select(groupElement("want_ext"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * uint64_t want_ext
+     * }
+     */
+    public static final OfLong want_ext$layout() {
+        return want_ext$LAYOUT;
+    }
+
+    private static final long want_ext$OFFSET = 56;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * uint64_t want_ext
+     * }
+     */
+    public static final long want_ext$offset() {
+        return want_ext$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * uint64_t want_ext
+     * }
+     */
+    public static long want_ext(MemorySegment struct) {
+        return struct.get(want_ext$LAYOUT, want_ext$OFFSET);
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * uint64_t want_ext
+     * }
+     */
+    public static void want_ext(MemorySegment struct, long fieldValue) {
+        struct.set(want_ext$LAYOUT, want_ext$OFFSET, fieldValue);
     }
 
     private static final SequenceLayout reserved$LAYOUT = (SequenceLayout)$LAYOUT.select(groupElement("reserved"));
@@ -501,19 +642,19 @@ public class fuse_conn_info {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int reserved[22]
+     * uint32_t reserved[16]
      * }
      */
     public static final SequenceLayout reserved$layout() {
         return reserved$LAYOUT;
     }
 
-    private static final long reserved$OFFSET = 40;
+    private static final long reserved$OFFSET = 64;
 
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int reserved[22]
+     * uint32_t reserved[16]
      * }
      */
     public static final long reserved$offset() {
@@ -523,7 +664,7 @@ public class fuse_conn_info {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int reserved[22]
+     * uint32_t reserved[16]
      * }
      */
     public static MemorySegment reserved(MemorySegment struct) {
@@ -533,19 +674,19 @@ public class fuse_conn_info {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int reserved[22]
+     * uint32_t reserved[16]
      * }
      */
     public static void reserved(MemorySegment struct, MemorySegment fieldValue) {
         MemorySegment.copy(fieldValue, 0L, struct, reserved$OFFSET, reserved$LAYOUT.byteSize());
     }
 
-    private static long[] reserved$DIMS = { 22 };
+    private static long[] reserved$DIMS = { 16 };
 
     /**
      * Dimensions for array field:
      * {@snippet lang=c :
-     * unsigned int reserved[22]
+     * uint32_t reserved[16]
      * }
      */
     public static long[] reserved$dimensions() {
@@ -556,7 +697,7 @@ public class fuse_conn_info {
     /**
      * Indexed getter for field:
      * {@snippet lang=c :
-     * unsigned int reserved[22]
+     * uint32_t reserved[16]
      * }
      */
     public static int reserved(MemorySegment struct, long index0) {
@@ -566,7 +707,7 @@ public class fuse_conn_info {
     /**
      * Indexed setter for field:
      * {@snippet lang=c :
-     * unsigned int reserved[22]
+     * uint32_t reserved[16]
      * }
      */
     public static void reserved(MemorySegment struct, long index0, int fieldValue) {
@@ -602,7 +743,7 @@ public class fuse_conn_info {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -610,7 +751,7 @@ public class fuse_conn_info {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/fuse3/fuse_file_info.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/fuse3/fuse_file_info.java
@@ -15,20 +15,25 @@ import static java.lang.foreign.MemoryLayout.PathElement.*;
 /**
  * {@snippet lang=c :
  * struct fuse_file_info {
- *     int flags;
- *     unsigned int writepage : 1;
- *     unsigned int direct_io : 1;
- *     unsigned int keep_cache : 1;
- *     unsigned int flush : 1;
- *     unsigned int nonseekable : 1;
- *     unsigned int flock_release : 1;
- *     unsigned int cache_readdir : 1;
- *     unsigned int noflush : 1;
- *     unsigned int padding : 24;
- *     unsigned int padding2 : 32;
+ *     int32_t flags;
+ *     uint32_t writepage : 1;
+ *     uint32_t direct_io : 1;
+ *     uint32_t keep_cache : 1;
+ *     uint32_t flush : 1;
+ *     uint32_t nonseekable : 1;
+ *     uint32_t flock_release : 1;
+ *     uint32_t cache_readdir : 1;
+ *     uint32_t noflush : 1;
+ *     uint32_t parallel_direct_writes : 1;
+ *     uint32_t padding : 23;
+ *     uint32_t padding2 : 32;
+ *     uint32_t padding3 : 32;
  *     uint64_t fh;
  *     uint64_t lock_owner;
  *     uint32_t poll_events;
+ *     int32_t backing_id;
+ *     uint64_t compat_flags;
+ *     uint64_t reserved[2];
  * }
  * }
  */
@@ -44,7 +49,9 @@ public class fuse_file_info {
         fuse_h.C_LONG.withName("fh"),
         fuse_h.C_LONG.withName("lock_owner"),
         fuse_h.C_INT.withName("poll_events"),
-        MemoryLayout.paddingLayout(4)
+        fuse_h.C_INT.withName("backing_id"),
+        fuse_h.C_LONG.withName("compat_flags"),
+        MemoryLayout.sequenceLayout(2, fuse_h.C_LONG).withName("reserved")
     ).withName("fuse_file_info");
 
     /**
@@ -59,7 +66,7 @@ public class fuse_file_info {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int flags
+     * int32_t flags
      * }
      */
     public static final OfInt flags$layout() {
@@ -71,7 +78,7 @@ public class fuse_file_info {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int flags
+     * int32_t flags
      * }
      */
     public static final long flags$offset() {
@@ -81,7 +88,7 @@ public class fuse_file_info {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int flags
+     * int32_t flags
      * }
      */
     public static int flags(MemorySegment struct) {
@@ -91,7 +98,7 @@ public class fuse_file_info {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int flags
+     * int32_t flags
      * }
      */
     public static void flags(MemorySegment struct, int fieldValue) {
@@ -230,6 +237,171 @@ public class fuse_file_info {
         struct.set(poll_events$LAYOUT, poll_events$OFFSET, fieldValue);
     }
 
+    private static final OfInt backing_id$LAYOUT = (OfInt)$LAYOUT.select(groupElement("backing_id"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * int32_t backing_id
+     * }
+     */
+    public static final OfInt backing_id$layout() {
+        return backing_id$LAYOUT;
+    }
+
+    private static final long backing_id$OFFSET = 36;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * int32_t backing_id
+     * }
+     */
+    public static final long backing_id$offset() {
+        return backing_id$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * int32_t backing_id
+     * }
+     */
+    public static int backing_id(MemorySegment struct) {
+        return struct.get(backing_id$LAYOUT, backing_id$OFFSET);
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * int32_t backing_id
+     * }
+     */
+    public static void backing_id(MemorySegment struct, int fieldValue) {
+        struct.set(backing_id$LAYOUT, backing_id$OFFSET, fieldValue);
+    }
+
+    private static final OfLong compat_flags$LAYOUT = (OfLong)$LAYOUT.select(groupElement("compat_flags"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * uint64_t compat_flags
+     * }
+     */
+    public static final OfLong compat_flags$layout() {
+        return compat_flags$LAYOUT;
+    }
+
+    private static final long compat_flags$OFFSET = 40;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * uint64_t compat_flags
+     * }
+     */
+    public static final long compat_flags$offset() {
+        return compat_flags$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * uint64_t compat_flags
+     * }
+     */
+    public static long compat_flags(MemorySegment struct) {
+        return struct.get(compat_flags$LAYOUT, compat_flags$OFFSET);
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * uint64_t compat_flags
+     * }
+     */
+    public static void compat_flags(MemorySegment struct, long fieldValue) {
+        struct.set(compat_flags$LAYOUT, compat_flags$OFFSET, fieldValue);
+    }
+
+    private static final SequenceLayout reserved$LAYOUT = (SequenceLayout)$LAYOUT.select(groupElement("reserved"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * uint64_t reserved[2]
+     * }
+     */
+    public static final SequenceLayout reserved$layout() {
+        return reserved$LAYOUT;
+    }
+
+    private static final long reserved$OFFSET = 48;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * uint64_t reserved[2]
+     * }
+     */
+    public static final long reserved$offset() {
+        return reserved$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * uint64_t reserved[2]
+     * }
+     */
+    public static MemorySegment reserved(MemorySegment struct) {
+        return struct.asSlice(reserved$OFFSET, reserved$LAYOUT.byteSize());
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * uint64_t reserved[2]
+     * }
+     */
+    public static void reserved(MemorySegment struct, MemorySegment fieldValue) {
+        MemorySegment.copy(fieldValue, 0L, struct, reserved$OFFSET, reserved$LAYOUT.byteSize());
+    }
+
+    private static long[] reserved$DIMS = { 2 };
+
+    /**
+     * Dimensions for array field:
+     * {@snippet lang=c :
+     * uint64_t reserved[2]
+     * }
+     */
+    public static long[] reserved$dimensions() {
+        return reserved$DIMS;
+    }
+    private static final VarHandle reserved$ELEM_HANDLE = reserved$LAYOUT.varHandle(sequenceElement());
+
+    /**
+     * Indexed getter for field:
+     * {@snippet lang=c :
+     * uint64_t reserved[2]
+     * }
+     */
+    public static long reserved(MemorySegment struct, long index0) {
+        return (long)reserved$ELEM_HANDLE.get(struct, 0L, index0);
+    }
+
+    /**
+     * Indexed setter for field:
+     * {@snippet lang=c :
+     * uint64_t reserved[2]
+     * }
+     */
+    public static void reserved(MemorySegment struct, long index0, long fieldValue) {
+        reserved$ELEM_HANDLE.set(struct, 0L, index0, fieldValue);
+    }
+
     /**
      * Obtains a slice of {@code arrayParam} which selects the array element at {@code index}.
      * The returned segment has address {@code arrayParam.address() + index * layout().byteSize()}
@@ -259,7 +431,7 @@ public class fuse_file_info {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -267,7 +439,7 @@ public class fuse_file_info {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/fuse3/fuse_fill_dir_t.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/fuse3/fuse_fill_dir_t.java
@@ -32,6 +32,7 @@ import static java.lang.foreign.MemoryLayout.PathElement.*;
  *     struct timespec st_ctim;
  *     int __glibc_reserved[2];
  * } *, off_t, enum fuse_fill_dir_flags {
+ *     FUSE_FILL_DIR_DEFAULTS = 0,
  *     FUSE_FILL_DIR_PLUS = (1 << 1)
  * })
  * }

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/fuse3/fuse_h.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/fuse3/fuse_h.java
@@ -73,9 +73,9 @@ public class fuse_h {
         public static final FunctionDescriptor DESC = FunctionDescriptor.of(
             fuse_h.C_INT    );
 
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_version"),
-                    DESC);
+        public static final MemorySegment ADDR = fuse_h.findOrThrow("fuse_version");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
 
     /**
@@ -97,6 +97,17 @@ public class fuse_h {
     public static MethodHandle fuse_version$handle() {
         return fuse_version.HANDLE;
     }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * int fuse_version()
+     * }
+     */
+    public static MemorySegment fuse_version$address() {
+        return fuse_version.ADDR;
+    }
+
     /**
      * {@snippet lang=c :
      * int fuse_version()
@@ -118,9 +129,9 @@ public class fuse_h {
         public static final FunctionDescriptor DESC = FunctionDescriptor.of(
             fuse_h.C_POINTER    );
 
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_loop_cfg_create"),
-                    DESC);
+        public static final MemorySegment ADDR = fuse_h.findOrThrow("fuse_loop_cfg_create");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
 
     /**
@@ -142,6 +153,17 @@ public class fuse_h {
     public static MethodHandle fuse_loop_cfg_create$handle() {
         return fuse_loop_cfg_create.HANDLE;
     }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * struct fuse_loop_config *fuse_loop_cfg_create()
+     * }
+     */
+    public static MemorySegment fuse_loop_cfg_create$address() {
+        return fuse_loop_cfg_create.ADDR;
+    }
+
     /**
      * {@snippet lang=c :
      * struct fuse_loop_config *fuse_loop_cfg_create()
@@ -164,9 +186,9 @@ public class fuse_h {
             fuse_h.C_POINTER
         );
 
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_loop_cfg_destroy"),
-                    DESC);
+        public static final MemorySegment ADDR = fuse_h.findOrThrow("fuse_loop_cfg_destroy");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
 
     /**
@@ -188,6 +210,17 @@ public class fuse_h {
     public static MethodHandle fuse_loop_cfg_destroy$handle() {
         return fuse_loop_cfg_destroy.HANDLE;
     }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * void fuse_loop_cfg_destroy(struct fuse_loop_config *config)
+     * }
+     */
+    public static MemorySegment fuse_loop_cfg_destroy$address() {
+        return fuse_loop_cfg_destroy.ADDR;
+    }
+
     /**
      * {@snippet lang=c :
      * void fuse_loop_cfg_destroy(struct fuse_loop_config *config)
@@ -211,9 +244,9 @@ public class fuse_h {
             fuse_h.C_INT
         );
 
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_loop_cfg_set_max_threads"),
-                    DESC);
+        public static final MemorySegment ADDR = fuse_h.findOrThrow("fuse_loop_cfg_set_max_threads");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
 
     /**
@@ -235,6 +268,17 @@ public class fuse_h {
     public static MethodHandle fuse_loop_cfg_set_max_threads$handle() {
         return fuse_loop_cfg_set_max_threads.HANDLE;
     }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * void fuse_loop_cfg_set_max_threads(struct fuse_loop_config *config, unsigned int value)
+     * }
+     */
+    public static MemorySegment fuse_loop_cfg_set_max_threads$address() {
+        return fuse_loop_cfg_set_max_threads.ADDR;
+    }
+
     /**
      * {@snippet lang=c :
      * void fuse_loop_cfg_set_max_threads(struct fuse_loop_config *config, unsigned int value)
@@ -258,9 +302,9 @@ public class fuse_h {
             fuse_h.C_INT
         );
 
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_loop_cfg_set_clone_fd"),
-                    DESC);
+        public static final MemorySegment ADDR = fuse_h.findOrThrow("fuse_loop_cfg_set_clone_fd");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
 
     /**
@@ -282,6 +326,17 @@ public class fuse_h {
     public static MethodHandle fuse_loop_cfg_set_clone_fd$handle() {
         return fuse_loop_cfg_set_clone_fd.HANDLE;
     }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * void fuse_loop_cfg_set_clone_fd(struct fuse_loop_config *config, unsigned int value)
+     * }
+     */
+    public static MemorySegment fuse_loop_cfg_set_clone_fd$address() {
+        return fuse_loop_cfg_set_clone_fd.ADDR;
+    }
+
     /**
      * {@snippet lang=c :
      * void fuse_loop_cfg_set_clone_fd(struct fuse_loop_config *config, unsigned int value)
@@ -304,9 +359,9 @@ public class fuse_h {
             fuse_h.C_POINTER
         );
 
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_lib_help"),
-                    DESC);
+        public static final MemorySegment ADDR = fuse_h.findOrThrow("fuse_lib_help");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
 
     /**
@@ -328,6 +383,17 @@ public class fuse_h {
     public static MethodHandle fuse_lib_help$handle() {
         return fuse_lib_help.HANDLE;
     }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * void fuse_lib_help(struct fuse_args *args)
+     * }
+     */
+    public static MemorySegment fuse_lib_help$address() {
+        return fuse_lib_help.ADDR;
+    }
+
     /**
      * {@snippet lang=c :
      * void fuse_lib_help(struct fuse_args *args)
@@ -345,56 +411,6 @@ public class fuse_h {
         }
     }
 
-    private static class fuse_new {
-        public static final FunctionDescriptor DESC = FunctionDescriptor.of(
-            fuse_h.C_POINTER,
-            fuse_h.C_POINTER,
-            fuse_h.C_POINTER,
-            fuse_h.C_LONG,
-            fuse_h.C_POINTER
-        );
-
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_new"),
-                    DESC);
-    }
-
-    /**
-     * Function descriptor for:
-     * {@snippet lang=c :
-     * struct fuse *fuse_new(struct fuse_args *args, const struct fuse_operations *op, size_t op_size, void *private_data)
-     * }
-     */
-    public static FunctionDescriptor fuse_new$descriptor() {
-        return fuse_new.DESC;
-    }
-
-    /**
-     * Downcall method handle for:
-     * {@snippet lang=c :
-     * struct fuse *fuse_new(struct fuse_args *args, const struct fuse_operations *op, size_t op_size, void *private_data)
-     * }
-     */
-    public static MethodHandle fuse_new$handle() {
-        return fuse_new.HANDLE;
-    }
-    /**
-     * {@snippet lang=c :
-     * struct fuse *fuse_new(struct fuse_args *args, const struct fuse_operations *op, size_t op_size, void *private_data)
-     * }
-     */
-    public static MemorySegment fuse_new(MemorySegment args, MemorySegment op, long op_size, MemorySegment private_data) {
-        var mh$ = fuse_new.HANDLE;
-        try {
-            if (TRACE_DOWNCALLS) {
-                traceDowncall("fuse_new", args, op, op_size, private_data);
-            }
-            return (MemorySegment)mh$.invokeExact(args, op, op_size, private_data);
-        } catch (Throwable ex$) {
-           throw new AssertionError("should not reach here", ex$);
-        }
-    }
-
     private static class fuse_mount {
         public static final FunctionDescriptor DESC = FunctionDescriptor.of(
             fuse_h.C_INT,
@@ -402,9 +418,9 @@ public class fuse_h {
             fuse_h.C_POINTER
         );
 
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_mount"),
-                    DESC);
+        public static final MemorySegment ADDR = fuse_h.findOrThrow("fuse_mount");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
 
     /**
@@ -426,6 +442,17 @@ public class fuse_h {
     public static MethodHandle fuse_mount$handle() {
         return fuse_mount.HANDLE;
     }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * int fuse_mount(struct fuse *f, const char *mountpoint)
+     * }
+     */
+    public static MemorySegment fuse_mount$address() {
+        return fuse_mount.ADDR;
+    }
+
     /**
      * {@snippet lang=c :
      * int fuse_mount(struct fuse *f, const char *mountpoint)
@@ -448,9 +475,9 @@ public class fuse_h {
             fuse_h.C_POINTER
         );
 
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_unmount"),
-                    DESC);
+        public static final MemorySegment ADDR = fuse_h.findOrThrow("fuse_unmount");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
 
     /**
@@ -472,6 +499,17 @@ public class fuse_h {
     public static MethodHandle fuse_unmount$handle() {
         return fuse_unmount.HANDLE;
     }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * void fuse_unmount(struct fuse *f)
+     * }
+     */
+    public static MemorySegment fuse_unmount$address() {
+        return fuse_unmount.ADDR;
+    }
+
     /**
      * {@snippet lang=c :
      * void fuse_unmount(struct fuse *f)
@@ -494,9 +532,9 @@ public class fuse_h {
             fuse_h.C_POINTER
         );
 
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_destroy"),
-                    DESC);
+        public static final MemorySegment ADDR = fuse_h.findOrThrow("fuse_destroy");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
 
     /**
@@ -518,6 +556,17 @@ public class fuse_h {
     public static MethodHandle fuse_destroy$handle() {
         return fuse_destroy.HANDLE;
     }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * void fuse_destroy(struct fuse *f)
+     * }
+     */
+    public static MemorySegment fuse_destroy$address() {
+        return fuse_destroy.ADDR;
+    }
+
     /**
      * {@snippet lang=c :
      * void fuse_destroy(struct fuse *f)
@@ -541,9 +590,9 @@ public class fuse_h {
             fuse_h.C_POINTER
         );
 
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_loop"),
-                    DESC);
+        public static final MemorySegment ADDR = fuse_h.findOrThrow("fuse_loop");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
 
     /**
@@ -565,6 +614,17 @@ public class fuse_h {
     public static MethodHandle fuse_loop$handle() {
         return fuse_loop.HANDLE;
     }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * int fuse_loop(struct fuse *f)
+     * }
+     */
+    public static MemorySegment fuse_loop$address() {
+        return fuse_loop.ADDR;
+    }
+
     /**
      * {@snippet lang=c :
      * int fuse_loop(struct fuse *f)
@@ -587,9 +647,9 @@ public class fuse_h {
             fuse_h.C_POINTER
         );
 
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_exit"),
-                    DESC);
+        public static final MemorySegment ADDR = fuse_h.findOrThrow("fuse_exit");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
 
     /**
@@ -611,6 +671,17 @@ public class fuse_h {
     public static MethodHandle fuse_exit$handle() {
         return fuse_exit.HANDLE;
     }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * void fuse_exit(struct fuse *f)
+     * }
+     */
+    public static MemorySegment fuse_exit$address() {
+        return fuse_exit.ADDR;
+    }
+
     /**
      * {@snippet lang=c :
      * void fuse_exit(struct fuse *f)
@@ -635,9 +706,9 @@ public class fuse_h {
             fuse_h.C_POINTER
         );
 
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_loop_mt"),
-                    DESC);
+        public static final MemorySegment ADDR = fuse_h.findOrThrow("fuse_loop_mt");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
 
     /**
@@ -659,6 +730,17 @@ public class fuse_h {
     public static MethodHandle fuse_loop_mt$handle() {
         return fuse_loop_mt.HANDLE;
     }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * int fuse_loop_mt(struct fuse *f, struct fuse_loop_config *config)
+     * }
+     */
+    public static MemorySegment fuse_loop_mt$address() {
+        return fuse_loop_mt.ADDR;
+    }
+
     /**
      * {@snippet lang=c :
      * int fuse_loop_mt(struct fuse *f, struct fuse_loop_config *config)
@@ -682,9 +764,9 @@ public class fuse_h {
             fuse_h.C_POINTER
         );
 
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_get_session"),
-                    DESC);
+        public static final MemorySegment ADDR = fuse_h.findOrThrow("fuse_get_session");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
 
     /**
@@ -706,6 +788,17 @@ public class fuse_h {
     public static MethodHandle fuse_get_session$handle() {
         return fuse_get_session.HANDLE;
     }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * struct fuse_session *fuse_get_session(struct fuse *f)
+     * }
+     */
+    public static MemorySegment fuse_get_session$address() {
+        return fuse_get_session.ADDR;
+    }
+
     /**
      * {@snippet lang=c :
      * struct fuse_session *fuse_get_session(struct fuse *f)

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/fuse3/fuse_loop_config_v1.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/fuse3/fuse_loop_config_v1.java
@@ -155,7 +155,7 @@ public class fuse_loop_config_v1 {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -163,7 +163,7 @@ public class fuse_loop_config_v1 {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/fuse3/fuse_operations.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/fuse3/fuse_operations.java
@@ -4355,7 +4355,7 @@ public class fuse_operations {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -4363,7 +4363,7 @@ public class fuse_operations {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/fuse3/stat.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/fuse3/stat.java
@@ -832,7 +832,7 @@ public class stat {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -840,7 +840,7 @@ public class stat {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/fuse3/statvfs.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/fuse3/statvfs.java
@@ -26,7 +26,8 @@ import static java.lang.foreign.MemoryLayout.PathElement.*;
  *     unsigned long f_fsid;
  *     unsigned long f_flag;
  *     unsigned long f_namemax;
- *     int __f_spare[6];
+ *     unsigned int f_type;
+ *     int __f_spare[5];
  * }
  * }
  */
@@ -48,7 +49,8 @@ public class statvfs {
         fuse_h.C_LONG.withName("f_fsid"),
         fuse_h.C_LONG.withName("f_flag"),
         fuse_h.C_LONG.withName("f_namemax"),
-        MemoryLayout.sequenceLayout(6, fuse_h.C_INT).withName("__f_spare")
+        fuse_h.C_INT.withName("f_type"),
+        MemoryLayout.sequenceLayout(5, fuse_h.C_INT).withName("__f_spare")
     ).withName("statvfs");
 
     /**
@@ -542,24 +544,68 @@ public class statvfs {
         struct.set(f_namemax$LAYOUT, f_namemax$OFFSET, fieldValue);
     }
 
+    private static final OfInt f_type$LAYOUT = (OfInt)$LAYOUT.select(groupElement("f_type"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * unsigned int f_type
+     * }
+     */
+    public static final OfInt f_type$layout() {
+        return f_type$LAYOUT;
+    }
+
+    private static final long f_type$OFFSET = 88;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * unsigned int f_type
+     * }
+     */
+    public static final long f_type$offset() {
+        return f_type$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * unsigned int f_type
+     * }
+     */
+    public static int f_type(MemorySegment struct) {
+        return struct.get(f_type$LAYOUT, f_type$OFFSET);
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * unsigned int f_type
+     * }
+     */
+    public static void f_type(MemorySegment struct, int fieldValue) {
+        struct.set(f_type$LAYOUT, f_type$OFFSET, fieldValue);
+    }
+
     private static final SequenceLayout __f_spare$LAYOUT = (SequenceLayout)$LAYOUT.select(groupElement("__f_spare"));
 
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int __f_spare[6]
+     * int __f_spare[5]
      * }
      */
     public static final SequenceLayout __f_spare$layout() {
         return __f_spare$LAYOUT;
     }
 
-    private static final long __f_spare$OFFSET = 88;
+    private static final long __f_spare$OFFSET = 92;
 
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int __f_spare[6]
+     * int __f_spare[5]
      * }
      */
     public static final long __f_spare$offset() {
@@ -569,7 +615,7 @@ public class statvfs {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int __f_spare[6]
+     * int __f_spare[5]
      * }
      */
     public static MemorySegment __f_spare(MemorySegment struct) {
@@ -579,19 +625,19 @@ public class statvfs {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int __f_spare[6]
+     * int __f_spare[5]
      * }
      */
     public static void __f_spare(MemorySegment struct, MemorySegment fieldValue) {
         MemorySegment.copy(fieldValue, 0L, struct, __f_spare$OFFSET, __f_spare$LAYOUT.byteSize());
     }
 
-    private static long[] __f_spare$DIMS = { 6 };
+    private static long[] __f_spare$DIMS = { 5 };
 
     /**
      * Dimensions for array field:
      * {@snippet lang=c :
-     * int __f_spare[6]
+     * int __f_spare[5]
      * }
      */
     public static long[] __f_spare$dimensions() {
@@ -602,7 +648,7 @@ public class statvfs {
     /**
      * Indexed getter for field:
      * {@snippet lang=c :
-     * int __f_spare[6]
+     * int __f_spare[5]
      * }
      */
     public static int __f_spare(MemorySegment struct, long index0) {
@@ -612,7 +658,7 @@ public class statvfs {
     /**
      * Indexed setter for field:
      * {@snippet lang=c :
-     * int __f_spare[6]
+     * int __f_spare[5]
      * }
      */
     public static void __f_spare(MemorySegment struct, long index0, int fieldValue) {
@@ -648,7 +694,7 @@ public class statvfs {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -656,7 +702,7 @@ public class statvfs {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/fuse3/timespec.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/fuse3/timespec.java
@@ -155,7 +155,7 @@ public class timespec {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -163,7 +163,7 @@ public class timespec {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/fuse3_lowlevel/fuse_cmdline_opts.java
+++ b/jfuse-linux-aarch64/src/main/java/org/cryptomator/jfuse/linux/aarch64/extr/fuse3_lowlevel/fuse_cmdline_opts.java
@@ -524,7 +524,7 @@ public class fuse_cmdline_opts {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -532,7 +532,7 @@ public class fuse_cmdline_opts {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/jfuse-linux-amd64/pom.xml
+++ b/jfuse-linux-amd64/pom.xml
@@ -99,12 +99,11 @@
 									<targetPackage>org.cryptomator.jfuse.linux.amd64.extr.fuse3</targetPackage>
 									<cPreprocessorMacros>
 										<cPreprocessorMacro>_FILE_OFFSET_BITS=64</cPreprocessorMacro>
-										<cPreprocessorMacro>FUSE_USE_VERSION=312</cPreprocessorMacro>
+										<cPreprocessorMacro>FUSE_USE_VERSION=317</cPreprocessorMacro>
 									</cPreprocessorMacros>
 									<includeFunctions>
 										<includeFunction>fuse_version</includeFunction>
 										<includeFunction>fuse_lib_help</includeFunction>
-										<includeFunction>fuse_new</includeFunction>
 										<includeFunction>fuse_mount</includeFunction>
 										<includeFunction>fuse_get_session</includeFunction>
 										<includeFunction>fuse_loop</includeFunction>
@@ -144,7 +143,7 @@
 									<headerClassName>fuse_lowlevel_h</headerClassName>
 									<cPreprocessorMacros>
 										<cPreprocessorMacro>_FILE_OFFSET_BITS=64</cPreprocessorMacro>
-										<cPreprocessorMacro>FUSE_USE_VERSION=312</cPreprocessorMacro>
+										<cPreprocessorMacro>FUSE_USE_VERSION=317</cPreprocessorMacro>
 									</cPreprocessorMacros>
 									<includeStructs>
 										<includeStruct>fuse_cmdline_opts</includeStruct>

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/FuseFFIHelper.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/FuseFFIHelper.java
@@ -11,9 +11,8 @@ import java.lang.invoke.MethodHandle;
 /**
  * Class for not jextract'able symbols, e.g. fuse_new_31
  */
-public class fuse_hHelper {
+public class FuseFFIHelper {
 
-	private static final String FUSE_NEW_SYMBOLNAME = "fuse_new_31";
 
 	static final SymbolLookup SYMBOL_LOOKUP = SymbolLookup.loaderLookup()
 			.or(Linker.nativeLinker().defaultLookup());
@@ -23,7 +22,7 @@ public class fuse_hHelper {
 				.orElseThrow(() -> new UnsatisfiedLinkError("unresolved symbol: " + symbol));
 	}
 
-	private static class fuse_new {
+	private static class fuse_new_31 {
 		public static final FunctionDescriptor DESC = FunctionDescriptor.of(
 				fuse_h.C_POINTER,
 				fuse_h.C_POINTER,
@@ -33,7 +32,7 @@ public class fuse_hHelper {
 		);
 
 		public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-				findOrThrow(FUSE_NEW_SYMBOLNAME),
+				findOrThrow("fuse_new_31"),
 				DESC);
 	}
 
@@ -43,8 +42,8 @@ public class fuse_hHelper {
 	 * struct fuse *fuse_new(struct fuse_args *args, const struct fuse_operations *op, size_t op_size, void *private_data)
 	 *}
 	 */
-	public static FunctionDescriptor fuse_new$descriptor() {
-		return fuse_new.DESC;
+	public static FunctionDescriptor fuse_new_31$descriptor() {
+		return fuse_new_31.DESC;
 	}
 
 
@@ -54,8 +53,8 @@ public class fuse_hHelper {
 	 * struct fuse *fuse_new(struct fuse_args *args, const struct fuse_operations *op, size_t op_size, void *private_data)
 	 *}
 	 */
-	public static MethodHandle fuse_new$handle() {
-		return fuse_new.HANDLE;
+	public static MethodHandle fuse_new_31$handle() {
+		return fuse_new_31.HANDLE;
 	}
 
 	/**
@@ -63,8 +62,8 @@ public class fuse_hHelper {
 	 * struct fuse *fuse_new(struct fuse_args *args, const struct fuse_operations *op, size_t op_size, void *private_data)
 	 *}
 	 */
-	public static MemorySegment fuse_new(MemorySegment args, MemorySegment op, long op_size, MemorySegment private_data) {
-		var mh$ = fuse_new.HANDLE;
+	public static MemorySegment fuse_new_31(MemorySegment args, MemorySegment op, long op_size, MemorySegment private_data) {
+		var mh$ = fuse_new_31.HANDLE;
 		try {
 			return (MemorySegment) mh$.invokeExact(args, op, op_size, private_data);
 		} catch (Throwable ex$) {

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/FuseImpl.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/FuseImpl.java
@@ -28,14 +28,20 @@ final class FuseImpl extends Fuse {
 	@Override
 	protected FuseMount mount(List<String> args) throws FuseMountFailedException {
 		var fuseArgs = parseArgs(args);
-		var fuse = fuse_hHelper.fuse_new(fuseArgs.args(), fuseOperationsStruct, fuseOperationsStruct.byteSize(), MemorySegment.NULL);
-		if (MemorySegment.NULL.equals(fuse)) {
-			throw new FuseMountFailedException("fuse_new failed");
-		}
+		var fuse = createFuseFS(fuseArgs);
 		if (fuse_h.fuse_mount(fuse, fuseArgs.mountPoint()) != 0) {
 			throw new FuseMountFailedException("fuse_mount failed");
 		}
 		return new FuseMountImpl(fuse, fuseArgs);
+	}
+
+	@VisibleForTesting
+	MemorySegment createFuseFS(FuseArgs fuseArgs) throws FuseMountFailedException {
+		var fuse = fuse_hHelper.fuse_new(fuseArgs.args(), fuseOperationsStruct, fuseOperationsStruct.byteSize(), MemorySegment.NULL);
+		if (MemorySegment.NULL.equals(fuse)) {
+			throw new FuseMountFailedException("fuse_new failed");
+		}
+		return fuse;
 	}
 
 	@VisibleForTesting

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/FuseImpl.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/FuseImpl.java
@@ -37,7 +37,7 @@ final class FuseImpl extends Fuse {
 
 	@VisibleForTesting
 	MemorySegment createFuseFS(FuseArgs fuseArgs) throws FuseMountFailedException {
-		var fuse = fuse_hHelper.fuse_new(fuseArgs.args(), fuseOperationsStruct, fuseOperationsStruct.byteSize(), MemorySegment.NULL);
+		var fuse = FuseFFIHelper.fuse_new_31(fuseArgs.args(), fuseOperationsStruct, fuseOperationsStruct.byteSize(), MemorySegment.NULL);
 		if (MemorySegment.NULL.equals(fuse)) {
 			throw new FuseMountFailedException("fuse_new failed");
 		}

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/FuseImpl.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/FuseImpl.java
@@ -28,7 +28,7 @@ final class FuseImpl extends Fuse {
 	@Override
 	protected FuseMount mount(List<String> args) throws FuseMountFailedException {
 		var fuseArgs = parseArgs(args);
-		var fuse = fuse_h.fuse_new(fuseArgs.args(), fuseOperationsStruct, fuseOperationsStruct.byteSize(), MemorySegment.NULL);
+		var fuse = fuse_hHelper.fuse_new(fuseArgs.args(), fuseOperationsStruct, fuseOperationsStruct.byteSize(), MemorySegment.NULL);
 		if (MemorySegment.NULL.equals(fuse)) {
 			throw new FuseMountFailedException("fuse_new failed");
 		}

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/fuse3/fuse_args.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/fuse3/fuse_args.java
@@ -203,7 +203,7 @@ public class fuse_args {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -211,7 +211,7 @@ public class fuse_args {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/fuse3/fuse_config.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/fuse3/fuse_config.java
@@ -15,31 +15,36 @@ import static java.lang.foreign.MemoryLayout.PathElement.*;
 /**
  * {@snippet lang=c :
  * struct fuse_config {
- *     int set_gid;
- *     unsigned int gid;
- *     int set_uid;
- *     unsigned int uid;
- *     int set_mode;
- *     unsigned int umask;
+ *     int32_t set_gid;
+ *     uint32_t gid;
+ *     int32_t set_uid;
+ *     uint32_t uid;
+ *     int32_t set_mode;
+ *     uint32_t umask;
  *     double entry_timeout;
  *     double negative_timeout;
  *     double attr_timeout;
- *     int intr;
- *     int intr_signal;
- *     int remember;
- *     int hard_remove;
- *     int use_ino;
- *     int readdir_ino;
- *     int direct_io;
- *     int kernel_cache;
- *     int auto_cache;
- *     int no_rofd_flush;
- *     int ac_attr_timeout_set;
+ *     int32_t intr;
+ *     int32_t intr_signal;
+ *     int32_t remember;
+ *     int32_t hard_remove;
+ *     int32_t use_ino;
+ *     int32_t readdir_ino;
+ *     int32_t direct_io;
+ *     int32_t kernel_cache;
+ *     int32_t auto_cache;
+ *     int32_t ac_attr_timeout_set;
  *     double ac_attr_timeout;
- *     int nullpath_ok;
- *     int show_help;
+ *     int32_t nullpath_ok;
+ *     int32_t show_help;
  *     char *modules;
- *     int debug;
+ *     int32_t debug;
+ *     uint32_t fmask;
+ *     uint32_t dmask;
+ *     int32_t no_rofd_flush;
+ *     int32_t parallel_direct_writes;
+ *     uint32_t flags;
+ *     uint64_t reserved[48];
  * }
  * }
  */
@@ -68,15 +73,18 @@ public class fuse_config {
         fuse_h.C_INT.withName("direct_io"),
         fuse_h.C_INT.withName("kernel_cache"),
         fuse_h.C_INT.withName("auto_cache"),
-        fuse_h.C_INT.withName("no_rofd_flush"),
         fuse_h.C_INT.withName("ac_attr_timeout_set"),
-        MemoryLayout.paddingLayout(4),
         fuse_h.C_DOUBLE.withName("ac_attr_timeout"),
         fuse_h.C_INT.withName("nullpath_ok"),
         fuse_h.C_INT.withName("show_help"),
         fuse_h.C_POINTER.withName("modules"),
         fuse_h.C_INT.withName("debug"),
-        MemoryLayout.paddingLayout(4)
+        fuse_h.C_INT.withName("fmask"),
+        fuse_h.C_INT.withName("dmask"),
+        fuse_h.C_INT.withName("no_rofd_flush"),
+        fuse_h.C_INT.withName("parallel_direct_writes"),
+        fuse_h.C_INT.withName("flags"),
+        MemoryLayout.sequenceLayout(48, fuse_h.C_LONG).withName("reserved")
     ).withName("fuse_config");
 
     /**
@@ -91,7 +99,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int set_gid
+     * int32_t set_gid
      * }
      */
     public static final OfInt set_gid$layout() {
@@ -103,7 +111,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int set_gid
+     * int32_t set_gid
      * }
      */
     public static final long set_gid$offset() {
@@ -113,7 +121,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int set_gid
+     * int32_t set_gid
      * }
      */
     public static int set_gid(MemorySegment struct) {
@@ -123,7 +131,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int set_gid
+     * int32_t set_gid
      * }
      */
     public static void set_gid(MemorySegment struct, int fieldValue) {
@@ -135,7 +143,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int gid
+     * uint32_t gid
      * }
      */
     public static final OfInt gid$layout() {
@@ -147,7 +155,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int gid
+     * uint32_t gid
      * }
      */
     public static final long gid$offset() {
@@ -157,7 +165,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int gid
+     * uint32_t gid
      * }
      */
     public static int gid(MemorySegment struct) {
@@ -167,7 +175,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int gid
+     * uint32_t gid
      * }
      */
     public static void gid(MemorySegment struct, int fieldValue) {
@@ -179,7 +187,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int set_uid
+     * int32_t set_uid
      * }
      */
     public static final OfInt set_uid$layout() {
@@ -191,7 +199,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int set_uid
+     * int32_t set_uid
      * }
      */
     public static final long set_uid$offset() {
@@ -201,7 +209,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int set_uid
+     * int32_t set_uid
      * }
      */
     public static int set_uid(MemorySegment struct) {
@@ -211,7 +219,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int set_uid
+     * int32_t set_uid
      * }
      */
     public static void set_uid(MemorySegment struct, int fieldValue) {
@@ -223,7 +231,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int uid
+     * uint32_t uid
      * }
      */
     public static final OfInt uid$layout() {
@@ -235,7 +243,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int uid
+     * uint32_t uid
      * }
      */
     public static final long uid$offset() {
@@ -245,7 +253,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int uid
+     * uint32_t uid
      * }
      */
     public static int uid(MemorySegment struct) {
@@ -255,7 +263,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int uid
+     * uint32_t uid
      * }
      */
     public static void uid(MemorySegment struct, int fieldValue) {
@@ -267,7 +275,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int set_mode
+     * int32_t set_mode
      * }
      */
     public static final OfInt set_mode$layout() {
@@ -279,7 +287,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int set_mode
+     * int32_t set_mode
      * }
      */
     public static final long set_mode$offset() {
@@ -289,7 +297,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int set_mode
+     * int32_t set_mode
      * }
      */
     public static int set_mode(MemorySegment struct) {
@@ -299,7 +307,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int set_mode
+     * int32_t set_mode
      * }
      */
     public static void set_mode(MemorySegment struct, int fieldValue) {
@@ -311,7 +319,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int umask
+     * uint32_t umask
      * }
      */
     public static final OfInt umask$layout() {
@@ -323,7 +331,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int umask
+     * uint32_t umask
      * }
      */
     public static final long umask$offset() {
@@ -333,7 +341,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int umask
+     * uint32_t umask
      * }
      */
     public static int umask(MemorySegment struct) {
@@ -343,7 +351,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int umask
+     * uint32_t umask
      * }
      */
     public static void umask(MemorySegment struct, int fieldValue) {
@@ -487,7 +495,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int intr
+     * int32_t intr
      * }
      */
     public static final OfInt intr$layout() {
@@ -499,7 +507,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int intr
+     * int32_t intr
      * }
      */
     public static final long intr$offset() {
@@ -509,7 +517,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int intr
+     * int32_t intr
      * }
      */
     public static int intr(MemorySegment struct) {
@@ -519,7 +527,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int intr
+     * int32_t intr
      * }
      */
     public static void intr(MemorySegment struct, int fieldValue) {
@@ -531,7 +539,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int intr_signal
+     * int32_t intr_signal
      * }
      */
     public static final OfInt intr_signal$layout() {
@@ -543,7 +551,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int intr_signal
+     * int32_t intr_signal
      * }
      */
     public static final long intr_signal$offset() {
@@ -553,7 +561,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int intr_signal
+     * int32_t intr_signal
      * }
      */
     public static int intr_signal(MemorySegment struct) {
@@ -563,7 +571,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int intr_signal
+     * int32_t intr_signal
      * }
      */
     public static void intr_signal(MemorySegment struct, int fieldValue) {
@@ -575,7 +583,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int remember
+     * int32_t remember
      * }
      */
     public static final OfInt remember$layout() {
@@ -587,7 +595,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int remember
+     * int32_t remember
      * }
      */
     public static final long remember$offset() {
@@ -597,7 +605,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int remember
+     * int32_t remember
      * }
      */
     public static int remember(MemorySegment struct) {
@@ -607,7 +615,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int remember
+     * int32_t remember
      * }
      */
     public static void remember(MemorySegment struct, int fieldValue) {
@@ -619,7 +627,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int hard_remove
+     * int32_t hard_remove
      * }
      */
     public static final OfInt hard_remove$layout() {
@@ -631,7 +639,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int hard_remove
+     * int32_t hard_remove
      * }
      */
     public static final long hard_remove$offset() {
@@ -641,7 +649,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int hard_remove
+     * int32_t hard_remove
      * }
      */
     public static int hard_remove(MemorySegment struct) {
@@ -651,7 +659,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int hard_remove
+     * int32_t hard_remove
      * }
      */
     public static void hard_remove(MemorySegment struct, int fieldValue) {
@@ -663,7 +671,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int use_ino
+     * int32_t use_ino
      * }
      */
     public static final OfInt use_ino$layout() {
@@ -675,7 +683,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int use_ino
+     * int32_t use_ino
      * }
      */
     public static final long use_ino$offset() {
@@ -685,7 +693,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int use_ino
+     * int32_t use_ino
      * }
      */
     public static int use_ino(MemorySegment struct) {
@@ -695,7 +703,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int use_ino
+     * int32_t use_ino
      * }
      */
     public static void use_ino(MemorySegment struct, int fieldValue) {
@@ -707,7 +715,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int readdir_ino
+     * int32_t readdir_ino
      * }
      */
     public static final OfInt readdir_ino$layout() {
@@ -719,7 +727,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int readdir_ino
+     * int32_t readdir_ino
      * }
      */
     public static final long readdir_ino$offset() {
@@ -729,7 +737,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int readdir_ino
+     * int32_t readdir_ino
      * }
      */
     public static int readdir_ino(MemorySegment struct) {
@@ -739,7 +747,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int readdir_ino
+     * int32_t readdir_ino
      * }
      */
     public static void readdir_ino(MemorySegment struct, int fieldValue) {
@@ -751,7 +759,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int direct_io
+     * int32_t direct_io
      * }
      */
     public static final OfInt direct_io$layout() {
@@ -763,7 +771,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int direct_io
+     * int32_t direct_io
      * }
      */
     public static final long direct_io$offset() {
@@ -773,7 +781,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int direct_io
+     * int32_t direct_io
      * }
      */
     public static int direct_io(MemorySegment struct) {
@@ -783,7 +791,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int direct_io
+     * int32_t direct_io
      * }
      */
     public static void direct_io(MemorySegment struct, int fieldValue) {
@@ -795,7 +803,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int kernel_cache
+     * int32_t kernel_cache
      * }
      */
     public static final OfInt kernel_cache$layout() {
@@ -807,7 +815,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int kernel_cache
+     * int32_t kernel_cache
      * }
      */
     public static final long kernel_cache$offset() {
@@ -817,7 +825,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int kernel_cache
+     * int32_t kernel_cache
      * }
      */
     public static int kernel_cache(MemorySegment struct) {
@@ -827,7 +835,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int kernel_cache
+     * int32_t kernel_cache
      * }
      */
     public static void kernel_cache(MemorySegment struct, int fieldValue) {
@@ -839,7 +847,7 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int auto_cache
+     * int32_t auto_cache
      * }
      */
     public static final OfInt auto_cache$layout() {
@@ -851,7 +859,7 @@ public class fuse_config {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int auto_cache
+     * int32_t auto_cache
      * }
      */
     public static final long auto_cache$offset() {
@@ -861,7 +869,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int auto_cache
+     * int32_t auto_cache
      * }
      */
     public static int auto_cache(MemorySegment struct) {
@@ -871,55 +879,11 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int auto_cache
+     * int32_t auto_cache
      * }
      */
     public static void auto_cache(MemorySegment struct, int fieldValue) {
         struct.set(auto_cache$LAYOUT, auto_cache$OFFSET, fieldValue);
-    }
-
-    private static final OfInt no_rofd_flush$LAYOUT = (OfInt)$LAYOUT.select(groupElement("no_rofd_flush"));
-
-    /**
-     * Layout for field:
-     * {@snippet lang=c :
-     * int no_rofd_flush
-     * }
-     */
-    public static final OfInt no_rofd_flush$layout() {
-        return no_rofd_flush$LAYOUT;
-    }
-
-    private static final long no_rofd_flush$OFFSET = 84;
-
-    /**
-     * Offset for field:
-     * {@snippet lang=c :
-     * int no_rofd_flush
-     * }
-     */
-    public static final long no_rofd_flush$offset() {
-        return no_rofd_flush$OFFSET;
-    }
-
-    /**
-     * Getter for field:
-     * {@snippet lang=c :
-     * int no_rofd_flush
-     * }
-     */
-    public static int no_rofd_flush(MemorySegment struct) {
-        return struct.get(no_rofd_flush$LAYOUT, no_rofd_flush$OFFSET);
-    }
-
-    /**
-     * Setter for field:
-     * {@snippet lang=c :
-     * int no_rofd_flush
-     * }
-     */
-    public static void no_rofd_flush(MemorySegment struct, int fieldValue) {
-        struct.set(no_rofd_flush$LAYOUT, no_rofd_flush$OFFSET, fieldValue);
     }
 
     private static final OfInt ac_attr_timeout_set$LAYOUT = (OfInt)$LAYOUT.select(groupElement("ac_attr_timeout_set"));
@@ -927,19 +891,19 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int ac_attr_timeout_set
+     * int32_t ac_attr_timeout_set
      * }
      */
     public static final OfInt ac_attr_timeout_set$layout() {
         return ac_attr_timeout_set$LAYOUT;
     }
 
-    private static final long ac_attr_timeout_set$OFFSET = 88;
+    private static final long ac_attr_timeout_set$OFFSET = 84;
 
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int ac_attr_timeout_set
+     * int32_t ac_attr_timeout_set
      * }
      */
     public static final long ac_attr_timeout_set$offset() {
@@ -949,7 +913,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int ac_attr_timeout_set
+     * int32_t ac_attr_timeout_set
      * }
      */
     public static int ac_attr_timeout_set(MemorySegment struct) {
@@ -959,7 +923,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int ac_attr_timeout_set
+     * int32_t ac_attr_timeout_set
      * }
      */
     public static void ac_attr_timeout_set(MemorySegment struct, int fieldValue) {
@@ -978,7 +942,7 @@ public class fuse_config {
         return ac_attr_timeout$LAYOUT;
     }
 
-    private static final long ac_attr_timeout$OFFSET = 96;
+    private static final long ac_attr_timeout$OFFSET = 88;
 
     /**
      * Offset for field:
@@ -1015,19 +979,19 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int nullpath_ok
+     * int32_t nullpath_ok
      * }
      */
     public static final OfInt nullpath_ok$layout() {
         return nullpath_ok$LAYOUT;
     }
 
-    private static final long nullpath_ok$OFFSET = 104;
+    private static final long nullpath_ok$OFFSET = 96;
 
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int nullpath_ok
+     * int32_t nullpath_ok
      * }
      */
     public static final long nullpath_ok$offset() {
@@ -1037,7 +1001,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int nullpath_ok
+     * int32_t nullpath_ok
      * }
      */
     public static int nullpath_ok(MemorySegment struct) {
@@ -1047,7 +1011,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int nullpath_ok
+     * int32_t nullpath_ok
      * }
      */
     public static void nullpath_ok(MemorySegment struct, int fieldValue) {
@@ -1059,19 +1023,19 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int show_help
+     * int32_t show_help
      * }
      */
     public static final OfInt show_help$layout() {
         return show_help$LAYOUT;
     }
 
-    private static final long show_help$OFFSET = 108;
+    private static final long show_help$OFFSET = 100;
 
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int show_help
+     * int32_t show_help
      * }
      */
     public static final long show_help$offset() {
@@ -1081,7 +1045,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int show_help
+     * int32_t show_help
      * }
      */
     public static int show_help(MemorySegment struct) {
@@ -1091,7 +1055,7 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int show_help
+     * int32_t show_help
      * }
      */
     public static void show_help(MemorySegment struct, int fieldValue) {
@@ -1110,7 +1074,7 @@ public class fuse_config {
         return modules$LAYOUT;
     }
 
-    private static final long modules$OFFSET = 112;
+    private static final long modules$OFFSET = 104;
 
     /**
      * Offset for field:
@@ -1147,19 +1111,19 @@ public class fuse_config {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int debug
+     * int32_t debug
      * }
      */
     public static final OfInt debug$layout() {
         return debug$LAYOUT;
     }
 
-    private static final long debug$OFFSET = 120;
+    private static final long debug$OFFSET = 112;
 
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int debug
+     * int32_t debug
      * }
      */
     public static final long debug$offset() {
@@ -1169,7 +1133,7 @@ public class fuse_config {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int debug
+     * int32_t debug
      * }
      */
     public static int debug(MemorySegment struct) {
@@ -1179,11 +1143,308 @@ public class fuse_config {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int debug
+     * int32_t debug
      * }
      */
     public static void debug(MemorySegment struct, int fieldValue) {
         struct.set(debug$LAYOUT, debug$OFFSET, fieldValue);
+    }
+
+    private static final OfInt fmask$LAYOUT = (OfInt)$LAYOUT.select(groupElement("fmask"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * uint32_t fmask
+     * }
+     */
+    public static final OfInt fmask$layout() {
+        return fmask$LAYOUT;
+    }
+
+    private static final long fmask$OFFSET = 116;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * uint32_t fmask
+     * }
+     */
+    public static final long fmask$offset() {
+        return fmask$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * uint32_t fmask
+     * }
+     */
+    public static int fmask(MemorySegment struct) {
+        return struct.get(fmask$LAYOUT, fmask$OFFSET);
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * uint32_t fmask
+     * }
+     */
+    public static void fmask(MemorySegment struct, int fieldValue) {
+        struct.set(fmask$LAYOUT, fmask$OFFSET, fieldValue);
+    }
+
+    private static final OfInt dmask$LAYOUT = (OfInt)$LAYOUT.select(groupElement("dmask"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * uint32_t dmask
+     * }
+     */
+    public static final OfInt dmask$layout() {
+        return dmask$LAYOUT;
+    }
+
+    private static final long dmask$OFFSET = 120;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * uint32_t dmask
+     * }
+     */
+    public static final long dmask$offset() {
+        return dmask$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * uint32_t dmask
+     * }
+     */
+    public static int dmask(MemorySegment struct) {
+        return struct.get(dmask$LAYOUT, dmask$OFFSET);
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * uint32_t dmask
+     * }
+     */
+    public static void dmask(MemorySegment struct, int fieldValue) {
+        struct.set(dmask$LAYOUT, dmask$OFFSET, fieldValue);
+    }
+
+    private static final OfInt no_rofd_flush$LAYOUT = (OfInt)$LAYOUT.select(groupElement("no_rofd_flush"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * int32_t no_rofd_flush
+     * }
+     */
+    public static final OfInt no_rofd_flush$layout() {
+        return no_rofd_flush$LAYOUT;
+    }
+
+    private static final long no_rofd_flush$OFFSET = 124;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * int32_t no_rofd_flush
+     * }
+     */
+    public static final long no_rofd_flush$offset() {
+        return no_rofd_flush$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * int32_t no_rofd_flush
+     * }
+     */
+    public static int no_rofd_flush(MemorySegment struct) {
+        return struct.get(no_rofd_flush$LAYOUT, no_rofd_flush$OFFSET);
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * int32_t no_rofd_flush
+     * }
+     */
+    public static void no_rofd_flush(MemorySegment struct, int fieldValue) {
+        struct.set(no_rofd_flush$LAYOUT, no_rofd_flush$OFFSET, fieldValue);
+    }
+
+    private static final OfInt parallel_direct_writes$LAYOUT = (OfInt)$LAYOUT.select(groupElement("parallel_direct_writes"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * int32_t parallel_direct_writes
+     * }
+     */
+    public static final OfInt parallel_direct_writes$layout() {
+        return parallel_direct_writes$LAYOUT;
+    }
+
+    private static final long parallel_direct_writes$OFFSET = 128;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * int32_t parallel_direct_writes
+     * }
+     */
+    public static final long parallel_direct_writes$offset() {
+        return parallel_direct_writes$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * int32_t parallel_direct_writes
+     * }
+     */
+    public static int parallel_direct_writes(MemorySegment struct) {
+        return struct.get(parallel_direct_writes$LAYOUT, parallel_direct_writes$OFFSET);
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * int32_t parallel_direct_writes
+     * }
+     */
+    public static void parallel_direct_writes(MemorySegment struct, int fieldValue) {
+        struct.set(parallel_direct_writes$LAYOUT, parallel_direct_writes$OFFSET, fieldValue);
+    }
+
+    private static final OfInt flags$LAYOUT = (OfInt)$LAYOUT.select(groupElement("flags"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * uint32_t flags
+     * }
+     */
+    public static final OfInt flags$layout() {
+        return flags$LAYOUT;
+    }
+
+    private static final long flags$OFFSET = 132;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * uint32_t flags
+     * }
+     */
+    public static final long flags$offset() {
+        return flags$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * uint32_t flags
+     * }
+     */
+    public static int flags(MemorySegment struct) {
+        return struct.get(flags$LAYOUT, flags$OFFSET);
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * uint32_t flags
+     * }
+     */
+    public static void flags(MemorySegment struct, int fieldValue) {
+        struct.set(flags$LAYOUT, flags$OFFSET, fieldValue);
+    }
+
+    private static final SequenceLayout reserved$LAYOUT = (SequenceLayout)$LAYOUT.select(groupElement("reserved"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * uint64_t reserved[48]
+     * }
+     */
+    public static final SequenceLayout reserved$layout() {
+        return reserved$LAYOUT;
+    }
+
+    private static final long reserved$OFFSET = 136;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * uint64_t reserved[48]
+     * }
+     */
+    public static final long reserved$offset() {
+        return reserved$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * uint64_t reserved[48]
+     * }
+     */
+    public static MemorySegment reserved(MemorySegment struct) {
+        return struct.asSlice(reserved$OFFSET, reserved$LAYOUT.byteSize());
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * uint64_t reserved[48]
+     * }
+     */
+    public static void reserved(MemorySegment struct, MemorySegment fieldValue) {
+        MemorySegment.copy(fieldValue, 0L, struct, reserved$OFFSET, reserved$LAYOUT.byteSize());
+    }
+
+    private static long[] reserved$DIMS = { 48 };
+
+    /**
+     * Dimensions for array field:
+     * {@snippet lang=c :
+     * uint64_t reserved[48]
+     * }
+     */
+    public static long[] reserved$dimensions() {
+        return reserved$DIMS;
+    }
+    private static final VarHandle reserved$ELEM_HANDLE = reserved$LAYOUT.varHandle(sequenceElement());
+
+    /**
+     * Indexed getter for field:
+     * {@snippet lang=c :
+     * uint64_t reserved[48]
+     * }
+     */
+    public static long reserved(MemorySegment struct, long index0) {
+        return (long)reserved$ELEM_HANDLE.get(struct, 0L, index0);
+    }
+
+    /**
+     * Indexed setter for field:
+     * {@snippet lang=c :
+     * uint64_t reserved[48]
+     * }
+     */
+    public static void reserved(MemorySegment struct, long index0, long fieldValue) {
+        reserved$ELEM_HANDLE.set(struct, 0L, index0, fieldValue);
     }
 
     /**
@@ -1215,7 +1476,7 @@ public class fuse_config {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -1223,7 +1484,7 @@ public class fuse_config {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/fuse3/fuse_conn_info.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/fuse3/fuse_conn_info.java
@@ -15,17 +15,22 @@ import static java.lang.foreign.MemoryLayout.PathElement.*;
 /**
  * {@snippet lang=c :
  * struct fuse_conn_info {
- *     unsigned int proto_major;
- *     unsigned int proto_minor;
- *     unsigned int max_write;
- *     unsigned int max_read;
- *     unsigned int max_readahead;
- *     unsigned int capable;
- *     unsigned int want;
- *     unsigned int max_background;
- *     unsigned int congestion_threshold;
- *     unsigned int time_gran;
- *     unsigned int reserved[22];
+ *     uint32_t proto_major;
+ *     uint32_t proto_minor;
+ *     uint32_t max_write;
+ *     uint32_t max_read;
+ *     uint32_t max_readahead;
+ *     uint32_t capable;
+ *     uint32_t want;
+ *     uint32_t max_background;
+ *     uint32_t congestion_threshold;
+ *     uint32_t time_gran;
+ *     uint32_t max_backing_stack_depth;
+ *     uint32_t no_interrupt : 1;
+ *     uint32_t padding : 31;
+ *     uint64_t capable_ext;
+ *     uint64_t want_ext;
+ *     uint32_t reserved[16];
  * }
  * }
  */
@@ -46,7 +51,11 @@ public class fuse_conn_info {
         fuse_h.C_INT.withName("max_background"),
         fuse_h.C_INT.withName("congestion_threshold"),
         fuse_h.C_INT.withName("time_gran"),
-        MemoryLayout.sequenceLayout(22, fuse_h.C_INT).withName("reserved")
+        fuse_h.C_INT.withName("max_backing_stack_depth"),
+        MemoryLayout.paddingLayout(4),
+        fuse_h.C_LONG.withName("capable_ext"),
+        fuse_h.C_LONG.withName("want_ext"),
+        MemoryLayout.sequenceLayout(16, fuse_h.C_INT).withName("reserved")
     ).withName("fuse_conn_info");
 
     /**
@@ -61,7 +70,7 @@ public class fuse_conn_info {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int proto_major
+     * uint32_t proto_major
      * }
      */
     public static final OfInt proto_major$layout() {
@@ -73,7 +82,7 @@ public class fuse_conn_info {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int proto_major
+     * uint32_t proto_major
      * }
      */
     public static final long proto_major$offset() {
@@ -83,7 +92,7 @@ public class fuse_conn_info {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int proto_major
+     * uint32_t proto_major
      * }
      */
     public static int proto_major(MemorySegment struct) {
@@ -93,7 +102,7 @@ public class fuse_conn_info {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int proto_major
+     * uint32_t proto_major
      * }
      */
     public static void proto_major(MemorySegment struct, int fieldValue) {
@@ -105,7 +114,7 @@ public class fuse_conn_info {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int proto_minor
+     * uint32_t proto_minor
      * }
      */
     public static final OfInt proto_minor$layout() {
@@ -117,7 +126,7 @@ public class fuse_conn_info {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int proto_minor
+     * uint32_t proto_minor
      * }
      */
     public static final long proto_minor$offset() {
@@ -127,7 +136,7 @@ public class fuse_conn_info {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int proto_minor
+     * uint32_t proto_minor
      * }
      */
     public static int proto_minor(MemorySegment struct) {
@@ -137,7 +146,7 @@ public class fuse_conn_info {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int proto_minor
+     * uint32_t proto_minor
      * }
      */
     public static void proto_minor(MemorySegment struct, int fieldValue) {
@@ -149,7 +158,7 @@ public class fuse_conn_info {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int max_write
+     * uint32_t max_write
      * }
      */
     public static final OfInt max_write$layout() {
@@ -161,7 +170,7 @@ public class fuse_conn_info {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int max_write
+     * uint32_t max_write
      * }
      */
     public static final long max_write$offset() {
@@ -171,7 +180,7 @@ public class fuse_conn_info {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int max_write
+     * uint32_t max_write
      * }
      */
     public static int max_write(MemorySegment struct) {
@@ -181,7 +190,7 @@ public class fuse_conn_info {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int max_write
+     * uint32_t max_write
      * }
      */
     public static void max_write(MemorySegment struct, int fieldValue) {
@@ -193,7 +202,7 @@ public class fuse_conn_info {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int max_read
+     * uint32_t max_read
      * }
      */
     public static final OfInt max_read$layout() {
@@ -205,7 +214,7 @@ public class fuse_conn_info {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int max_read
+     * uint32_t max_read
      * }
      */
     public static final long max_read$offset() {
@@ -215,7 +224,7 @@ public class fuse_conn_info {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int max_read
+     * uint32_t max_read
      * }
      */
     public static int max_read(MemorySegment struct) {
@@ -225,7 +234,7 @@ public class fuse_conn_info {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int max_read
+     * uint32_t max_read
      * }
      */
     public static void max_read(MemorySegment struct, int fieldValue) {
@@ -237,7 +246,7 @@ public class fuse_conn_info {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int max_readahead
+     * uint32_t max_readahead
      * }
      */
     public static final OfInt max_readahead$layout() {
@@ -249,7 +258,7 @@ public class fuse_conn_info {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int max_readahead
+     * uint32_t max_readahead
      * }
      */
     public static final long max_readahead$offset() {
@@ -259,7 +268,7 @@ public class fuse_conn_info {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int max_readahead
+     * uint32_t max_readahead
      * }
      */
     public static int max_readahead(MemorySegment struct) {
@@ -269,7 +278,7 @@ public class fuse_conn_info {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int max_readahead
+     * uint32_t max_readahead
      * }
      */
     public static void max_readahead(MemorySegment struct, int fieldValue) {
@@ -281,7 +290,7 @@ public class fuse_conn_info {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int capable
+     * uint32_t capable
      * }
      */
     public static final OfInt capable$layout() {
@@ -293,7 +302,7 @@ public class fuse_conn_info {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int capable
+     * uint32_t capable
      * }
      */
     public static final long capable$offset() {
@@ -303,7 +312,7 @@ public class fuse_conn_info {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int capable
+     * uint32_t capable
      * }
      */
     public static int capable(MemorySegment struct) {
@@ -313,7 +322,7 @@ public class fuse_conn_info {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int capable
+     * uint32_t capable
      * }
      */
     public static void capable(MemorySegment struct, int fieldValue) {
@@ -325,7 +334,7 @@ public class fuse_conn_info {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int want
+     * uint32_t want
      * }
      */
     public static final OfInt want$layout() {
@@ -337,7 +346,7 @@ public class fuse_conn_info {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int want
+     * uint32_t want
      * }
      */
     public static final long want$offset() {
@@ -347,7 +356,7 @@ public class fuse_conn_info {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int want
+     * uint32_t want
      * }
      */
     public static int want(MemorySegment struct) {
@@ -357,7 +366,7 @@ public class fuse_conn_info {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int want
+     * uint32_t want
      * }
      */
     public static void want(MemorySegment struct, int fieldValue) {
@@ -369,7 +378,7 @@ public class fuse_conn_info {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int max_background
+     * uint32_t max_background
      * }
      */
     public static final OfInt max_background$layout() {
@@ -381,7 +390,7 @@ public class fuse_conn_info {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int max_background
+     * uint32_t max_background
      * }
      */
     public static final long max_background$offset() {
@@ -391,7 +400,7 @@ public class fuse_conn_info {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int max_background
+     * uint32_t max_background
      * }
      */
     public static int max_background(MemorySegment struct) {
@@ -401,7 +410,7 @@ public class fuse_conn_info {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int max_background
+     * uint32_t max_background
      * }
      */
     public static void max_background(MemorySegment struct, int fieldValue) {
@@ -413,7 +422,7 @@ public class fuse_conn_info {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int congestion_threshold
+     * uint32_t congestion_threshold
      * }
      */
     public static final OfInt congestion_threshold$layout() {
@@ -425,7 +434,7 @@ public class fuse_conn_info {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int congestion_threshold
+     * uint32_t congestion_threshold
      * }
      */
     public static final long congestion_threshold$offset() {
@@ -435,7 +444,7 @@ public class fuse_conn_info {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int congestion_threshold
+     * uint32_t congestion_threshold
      * }
      */
     public static int congestion_threshold(MemorySegment struct) {
@@ -445,7 +454,7 @@ public class fuse_conn_info {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int congestion_threshold
+     * uint32_t congestion_threshold
      * }
      */
     public static void congestion_threshold(MemorySegment struct, int fieldValue) {
@@ -457,7 +466,7 @@ public class fuse_conn_info {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int time_gran
+     * uint32_t time_gran
      * }
      */
     public static final OfInt time_gran$layout() {
@@ -469,7 +478,7 @@ public class fuse_conn_info {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int time_gran
+     * uint32_t time_gran
      * }
      */
     public static final long time_gran$offset() {
@@ -479,7 +488,7 @@ public class fuse_conn_info {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int time_gran
+     * uint32_t time_gran
      * }
      */
     public static int time_gran(MemorySegment struct) {
@@ -489,11 +498,143 @@ public class fuse_conn_info {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int time_gran
+     * uint32_t time_gran
      * }
      */
     public static void time_gran(MemorySegment struct, int fieldValue) {
         struct.set(time_gran$LAYOUT, time_gran$OFFSET, fieldValue);
+    }
+
+    private static final OfInt max_backing_stack_depth$LAYOUT = (OfInt)$LAYOUT.select(groupElement("max_backing_stack_depth"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * uint32_t max_backing_stack_depth
+     * }
+     */
+    public static final OfInt max_backing_stack_depth$layout() {
+        return max_backing_stack_depth$LAYOUT;
+    }
+
+    private static final long max_backing_stack_depth$OFFSET = 40;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * uint32_t max_backing_stack_depth
+     * }
+     */
+    public static final long max_backing_stack_depth$offset() {
+        return max_backing_stack_depth$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * uint32_t max_backing_stack_depth
+     * }
+     */
+    public static int max_backing_stack_depth(MemorySegment struct) {
+        return struct.get(max_backing_stack_depth$LAYOUT, max_backing_stack_depth$OFFSET);
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * uint32_t max_backing_stack_depth
+     * }
+     */
+    public static void max_backing_stack_depth(MemorySegment struct, int fieldValue) {
+        struct.set(max_backing_stack_depth$LAYOUT, max_backing_stack_depth$OFFSET, fieldValue);
+    }
+
+    private static final OfLong capable_ext$LAYOUT = (OfLong)$LAYOUT.select(groupElement("capable_ext"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * uint64_t capable_ext
+     * }
+     */
+    public static final OfLong capable_ext$layout() {
+        return capable_ext$LAYOUT;
+    }
+
+    private static final long capable_ext$OFFSET = 48;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * uint64_t capable_ext
+     * }
+     */
+    public static final long capable_ext$offset() {
+        return capable_ext$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * uint64_t capable_ext
+     * }
+     */
+    public static long capable_ext(MemorySegment struct) {
+        return struct.get(capable_ext$LAYOUT, capable_ext$OFFSET);
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * uint64_t capable_ext
+     * }
+     */
+    public static void capable_ext(MemorySegment struct, long fieldValue) {
+        struct.set(capable_ext$LAYOUT, capable_ext$OFFSET, fieldValue);
+    }
+
+    private static final OfLong want_ext$LAYOUT = (OfLong)$LAYOUT.select(groupElement("want_ext"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * uint64_t want_ext
+     * }
+     */
+    public static final OfLong want_ext$layout() {
+        return want_ext$LAYOUT;
+    }
+
+    private static final long want_ext$OFFSET = 56;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * uint64_t want_ext
+     * }
+     */
+    public static final long want_ext$offset() {
+        return want_ext$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * uint64_t want_ext
+     * }
+     */
+    public static long want_ext(MemorySegment struct) {
+        return struct.get(want_ext$LAYOUT, want_ext$OFFSET);
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * uint64_t want_ext
+     * }
+     */
+    public static void want_ext(MemorySegment struct, long fieldValue) {
+        struct.set(want_ext$LAYOUT, want_ext$OFFSET, fieldValue);
     }
 
     private static final SequenceLayout reserved$LAYOUT = (SequenceLayout)$LAYOUT.select(groupElement("reserved"));
@@ -501,19 +642,19 @@ public class fuse_conn_info {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * unsigned int reserved[22]
+     * uint32_t reserved[16]
      * }
      */
     public static final SequenceLayout reserved$layout() {
         return reserved$LAYOUT;
     }
 
-    private static final long reserved$OFFSET = 40;
+    private static final long reserved$OFFSET = 64;
 
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * unsigned int reserved[22]
+     * uint32_t reserved[16]
      * }
      */
     public static final long reserved$offset() {
@@ -523,7 +664,7 @@ public class fuse_conn_info {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * unsigned int reserved[22]
+     * uint32_t reserved[16]
      * }
      */
     public static MemorySegment reserved(MemorySegment struct) {
@@ -533,19 +674,19 @@ public class fuse_conn_info {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * unsigned int reserved[22]
+     * uint32_t reserved[16]
      * }
      */
     public static void reserved(MemorySegment struct, MemorySegment fieldValue) {
         MemorySegment.copy(fieldValue, 0L, struct, reserved$OFFSET, reserved$LAYOUT.byteSize());
     }
 
-    private static long[] reserved$DIMS = { 22 };
+    private static long[] reserved$DIMS = { 16 };
 
     /**
      * Dimensions for array field:
      * {@snippet lang=c :
-     * unsigned int reserved[22]
+     * uint32_t reserved[16]
      * }
      */
     public static long[] reserved$dimensions() {
@@ -556,7 +697,7 @@ public class fuse_conn_info {
     /**
      * Indexed getter for field:
      * {@snippet lang=c :
-     * unsigned int reserved[22]
+     * uint32_t reserved[16]
      * }
      */
     public static int reserved(MemorySegment struct, long index0) {
@@ -566,7 +707,7 @@ public class fuse_conn_info {
     /**
      * Indexed setter for field:
      * {@snippet lang=c :
-     * unsigned int reserved[22]
+     * uint32_t reserved[16]
      * }
      */
     public static void reserved(MemorySegment struct, long index0, int fieldValue) {
@@ -602,7 +743,7 @@ public class fuse_conn_info {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -610,7 +751,7 @@ public class fuse_conn_info {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/fuse3/fuse_file_info.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/fuse3/fuse_file_info.java
@@ -15,20 +15,25 @@ import static java.lang.foreign.MemoryLayout.PathElement.*;
 /**
  * {@snippet lang=c :
  * struct fuse_file_info {
- *     int flags;
- *     unsigned int writepage : 1;
- *     unsigned int direct_io : 1;
- *     unsigned int keep_cache : 1;
- *     unsigned int flush : 1;
- *     unsigned int nonseekable : 1;
- *     unsigned int flock_release : 1;
- *     unsigned int cache_readdir : 1;
- *     unsigned int noflush : 1;
- *     unsigned int padding : 24;
- *     unsigned int padding2 : 32;
+ *     int32_t flags;
+ *     uint32_t writepage : 1;
+ *     uint32_t direct_io : 1;
+ *     uint32_t keep_cache : 1;
+ *     uint32_t flush : 1;
+ *     uint32_t nonseekable : 1;
+ *     uint32_t flock_release : 1;
+ *     uint32_t cache_readdir : 1;
+ *     uint32_t noflush : 1;
+ *     uint32_t parallel_direct_writes : 1;
+ *     uint32_t padding : 23;
+ *     uint32_t padding2 : 32;
+ *     uint32_t padding3 : 32;
  *     uint64_t fh;
  *     uint64_t lock_owner;
  *     uint32_t poll_events;
+ *     int32_t backing_id;
+ *     uint64_t compat_flags;
+ *     uint64_t reserved[2];
  * }
  * }
  */
@@ -44,7 +49,9 @@ public class fuse_file_info {
         fuse_h.C_LONG.withName("fh"),
         fuse_h.C_LONG.withName("lock_owner"),
         fuse_h.C_INT.withName("poll_events"),
-        MemoryLayout.paddingLayout(4)
+        fuse_h.C_INT.withName("backing_id"),
+        fuse_h.C_LONG.withName("compat_flags"),
+        MemoryLayout.sequenceLayout(2, fuse_h.C_LONG).withName("reserved")
     ).withName("fuse_file_info");
 
     /**
@@ -59,7 +66,7 @@ public class fuse_file_info {
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int flags
+     * int32_t flags
      * }
      */
     public static final OfInt flags$layout() {
@@ -71,7 +78,7 @@ public class fuse_file_info {
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int flags
+     * int32_t flags
      * }
      */
     public static final long flags$offset() {
@@ -81,7 +88,7 @@ public class fuse_file_info {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int flags
+     * int32_t flags
      * }
      */
     public static int flags(MemorySegment struct) {
@@ -91,7 +98,7 @@ public class fuse_file_info {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int flags
+     * int32_t flags
      * }
      */
     public static void flags(MemorySegment struct, int fieldValue) {
@@ -230,6 +237,171 @@ public class fuse_file_info {
         struct.set(poll_events$LAYOUT, poll_events$OFFSET, fieldValue);
     }
 
+    private static final OfInt backing_id$LAYOUT = (OfInt)$LAYOUT.select(groupElement("backing_id"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * int32_t backing_id
+     * }
+     */
+    public static final OfInt backing_id$layout() {
+        return backing_id$LAYOUT;
+    }
+
+    private static final long backing_id$OFFSET = 36;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * int32_t backing_id
+     * }
+     */
+    public static final long backing_id$offset() {
+        return backing_id$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * int32_t backing_id
+     * }
+     */
+    public static int backing_id(MemorySegment struct) {
+        return struct.get(backing_id$LAYOUT, backing_id$OFFSET);
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * int32_t backing_id
+     * }
+     */
+    public static void backing_id(MemorySegment struct, int fieldValue) {
+        struct.set(backing_id$LAYOUT, backing_id$OFFSET, fieldValue);
+    }
+
+    private static final OfLong compat_flags$LAYOUT = (OfLong)$LAYOUT.select(groupElement("compat_flags"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * uint64_t compat_flags
+     * }
+     */
+    public static final OfLong compat_flags$layout() {
+        return compat_flags$LAYOUT;
+    }
+
+    private static final long compat_flags$OFFSET = 40;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * uint64_t compat_flags
+     * }
+     */
+    public static final long compat_flags$offset() {
+        return compat_flags$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * uint64_t compat_flags
+     * }
+     */
+    public static long compat_flags(MemorySegment struct) {
+        return struct.get(compat_flags$LAYOUT, compat_flags$OFFSET);
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * uint64_t compat_flags
+     * }
+     */
+    public static void compat_flags(MemorySegment struct, long fieldValue) {
+        struct.set(compat_flags$LAYOUT, compat_flags$OFFSET, fieldValue);
+    }
+
+    private static final SequenceLayout reserved$LAYOUT = (SequenceLayout)$LAYOUT.select(groupElement("reserved"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * uint64_t reserved[2]
+     * }
+     */
+    public static final SequenceLayout reserved$layout() {
+        return reserved$LAYOUT;
+    }
+
+    private static final long reserved$OFFSET = 48;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * uint64_t reserved[2]
+     * }
+     */
+    public static final long reserved$offset() {
+        return reserved$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * uint64_t reserved[2]
+     * }
+     */
+    public static MemorySegment reserved(MemorySegment struct) {
+        return struct.asSlice(reserved$OFFSET, reserved$LAYOUT.byteSize());
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * uint64_t reserved[2]
+     * }
+     */
+    public static void reserved(MemorySegment struct, MemorySegment fieldValue) {
+        MemorySegment.copy(fieldValue, 0L, struct, reserved$OFFSET, reserved$LAYOUT.byteSize());
+    }
+
+    private static long[] reserved$DIMS = { 2 };
+
+    /**
+     * Dimensions for array field:
+     * {@snippet lang=c :
+     * uint64_t reserved[2]
+     * }
+     */
+    public static long[] reserved$dimensions() {
+        return reserved$DIMS;
+    }
+    private static final VarHandle reserved$ELEM_HANDLE = reserved$LAYOUT.varHandle(sequenceElement());
+
+    /**
+     * Indexed getter for field:
+     * {@snippet lang=c :
+     * uint64_t reserved[2]
+     * }
+     */
+    public static long reserved(MemorySegment struct, long index0) {
+        return (long)reserved$ELEM_HANDLE.get(struct, 0L, index0);
+    }
+
+    /**
+     * Indexed setter for field:
+     * {@snippet lang=c :
+     * uint64_t reserved[2]
+     * }
+     */
+    public static void reserved(MemorySegment struct, long index0, long fieldValue) {
+        reserved$ELEM_HANDLE.set(struct, 0L, index0, fieldValue);
+    }
+
     /**
      * Obtains a slice of {@code arrayParam} which selects the array element at {@code index}.
      * The returned segment has address {@code arrayParam.address() + index * layout().byteSize()}
@@ -259,7 +431,7 @@ public class fuse_file_info {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -267,7 +439,7 @@ public class fuse_file_info {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/fuse3/fuse_fill_dir_t.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/fuse3/fuse_fill_dir_t.java
@@ -31,6 +31,7 @@ import static java.lang.foreign.MemoryLayout.PathElement.*;
  *     struct timespec st_ctim;
  *     __syscall_slong_t __glibc_reserved[3];
  * } *, off_t, enum fuse_fill_dir_flags {
+ *     FUSE_FILL_DIR_DEFAULTS = 0,
  *     FUSE_FILL_DIR_PLUS = (1 << 1)
  * })
  * }

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/fuse3/fuse_h.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/fuse3/fuse_h.java
@@ -73,9 +73,9 @@ public class fuse_h {
         public static final FunctionDescriptor DESC = FunctionDescriptor.of(
             fuse_h.C_INT    );
 
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_version"),
-                    DESC);
+        public static final MemorySegment ADDR = fuse_h.findOrThrow("fuse_version");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
 
     /**
@@ -97,6 +97,17 @@ public class fuse_h {
     public static MethodHandle fuse_version$handle() {
         return fuse_version.HANDLE;
     }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * int fuse_version()
+     * }
+     */
+    public static MemorySegment fuse_version$address() {
+        return fuse_version.ADDR;
+    }
+
     /**
      * {@snippet lang=c :
      * int fuse_version()
@@ -118,9 +129,9 @@ public class fuse_h {
         public static final FunctionDescriptor DESC = FunctionDescriptor.of(
             fuse_h.C_POINTER    );
 
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_loop_cfg_create"),
-                    DESC);
+        public static final MemorySegment ADDR = fuse_h.findOrThrow("fuse_loop_cfg_create");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
 
     /**
@@ -142,6 +153,17 @@ public class fuse_h {
     public static MethodHandle fuse_loop_cfg_create$handle() {
         return fuse_loop_cfg_create.HANDLE;
     }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * struct fuse_loop_config *fuse_loop_cfg_create()
+     * }
+     */
+    public static MemorySegment fuse_loop_cfg_create$address() {
+        return fuse_loop_cfg_create.ADDR;
+    }
+
     /**
      * {@snippet lang=c :
      * struct fuse_loop_config *fuse_loop_cfg_create()
@@ -164,9 +186,9 @@ public class fuse_h {
             fuse_h.C_POINTER
         );
 
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_loop_cfg_destroy"),
-                    DESC);
+        public static final MemorySegment ADDR = fuse_h.findOrThrow("fuse_loop_cfg_destroy");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
 
     /**
@@ -188,6 +210,17 @@ public class fuse_h {
     public static MethodHandle fuse_loop_cfg_destroy$handle() {
         return fuse_loop_cfg_destroy.HANDLE;
     }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * void fuse_loop_cfg_destroy(struct fuse_loop_config *config)
+     * }
+     */
+    public static MemorySegment fuse_loop_cfg_destroy$address() {
+        return fuse_loop_cfg_destroy.ADDR;
+    }
+
     /**
      * {@snippet lang=c :
      * void fuse_loop_cfg_destroy(struct fuse_loop_config *config)
@@ -211,9 +244,9 @@ public class fuse_h {
             fuse_h.C_INT
         );
 
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_loop_cfg_set_max_threads"),
-                    DESC);
+        public static final MemorySegment ADDR = fuse_h.findOrThrow("fuse_loop_cfg_set_max_threads");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
 
     /**
@@ -235,6 +268,17 @@ public class fuse_h {
     public static MethodHandle fuse_loop_cfg_set_max_threads$handle() {
         return fuse_loop_cfg_set_max_threads.HANDLE;
     }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * void fuse_loop_cfg_set_max_threads(struct fuse_loop_config *config, unsigned int value)
+     * }
+     */
+    public static MemorySegment fuse_loop_cfg_set_max_threads$address() {
+        return fuse_loop_cfg_set_max_threads.ADDR;
+    }
+
     /**
      * {@snippet lang=c :
      * void fuse_loop_cfg_set_max_threads(struct fuse_loop_config *config, unsigned int value)
@@ -258,9 +302,9 @@ public class fuse_h {
             fuse_h.C_INT
         );
 
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_loop_cfg_set_clone_fd"),
-                    DESC);
+        public static final MemorySegment ADDR = fuse_h.findOrThrow("fuse_loop_cfg_set_clone_fd");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
 
     /**
@@ -282,6 +326,17 @@ public class fuse_h {
     public static MethodHandle fuse_loop_cfg_set_clone_fd$handle() {
         return fuse_loop_cfg_set_clone_fd.HANDLE;
     }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * void fuse_loop_cfg_set_clone_fd(struct fuse_loop_config *config, unsigned int value)
+     * }
+     */
+    public static MemorySegment fuse_loop_cfg_set_clone_fd$address() {
+        return fuse_loop_cfg_set_clone_fd.ADDR;
+    }
+
     /**
      * {@snippet lang=c :
      * void fuse_loop_cfg_set_clone_fd(struct fuse_loop_config *config, unsigned int value)
@@ -304,9 +359,9 @@ public class fuse_h {
             fuse_h.C_POINTER
         );
 
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_lib_help"),
-                    DESC);
+        public static final MemorySegment ADDR = fuse_h.findOrThrow("fuse_lib_help");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
 
     /**
@@ -328,6 +383,17 @@ public class fuse_h {
     public static MethodHandle fuse_lib_help$handle() {
         return fuse_lib_help.HANDLE;
     }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * void fuse_lib_help(struct fuse_args *args)
+     * }
+     */
+    public static MemorySegment fuse_lib_help$address() {
+        return fuse_lib_help.ADDR;
+    }
+
     /**
      * {@snippet lang=c :
      * void fuse_lib_help(struct fuse_args *args)
@@ -345,56 +411,6 @@ public class fuse_h {
         }
     }
 
-    private static class fuse_new {
-        public static final FunctionDescriptor DESC = FunctionDescriptor.of(
-            fuse_h.C_POINTER,
-            fuse_h.C_POINTER,
-            fuse_h.C_POINTER,
-            fuse_h.C_LONG,
-            fuse_h.C_POINTER
-        );
-
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_new"),
-                    DESC);
-    }
-
-    /**
-     * Function descriptor for:
-     * {@snippet lang=c :
-     * struct fuse *fuse_new(struct fuse_args *args, const struct fuse_operations *op, size_t op_size, void *private_data)
-     * }
-     */
-    public static FunctionDescriptor fuse_new$descriptor() {
-        return fuse_new.DESC;
-    }
-
-    /**
-     * Downcall method handle for:
-     * {@snippet lang=c :
-     * struct fuse *fuse_new(struct fuse_args *args, const struct fuse_operations *op, size_t op_size, void *private_data)
-     * }
-     */
-    public static MethodHandle fuse_new$handle() {
-        return fuse_new.HANDLE;
-    }
-    /**
-     * {@snippet lang=c :
-     * struct fuse *fuse_new(struct fuse_args *args, const struct fuse_operations *op, size_t op_size, void *private_data)
-     * }
-     */
-    public static MemorySegment fuse_new(MemorySegment args, MemorySegment op, long op_size, MemorySegment private_data) {
-        var mh$ = fuse_new.HANDLE;
-        try {
-            if (TRACE_DOWNCALLS) {
-                traceDowncall("fuse_new", args, op, op_size, private_data);
-            }
-            return (MemorySegment)mh$.invokeExact(args, op, op_size, private_data);
-        } catch (Throwable ex$) {
-           throw new AssertionError("should not reach here", ex$);
-        }
-    }
-
     private static class fuse_mount {
         public static final FunctionDescriptor DESC = FunctionDescriptor.of(
             fuse_h.C_INT,
@@ -402,9 +418,9 @@ public class fuse_h {
             fuse_h.C_POINTER
         );
 
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_mount"),
-                    DESC);
+        public static final MemorySegment ADDR = fuse_h.findOrThrow("fuse_mount");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
 
     /**
@@ -426,6 +442,17 @@ public class fuse_h {
     public static MethodHandle fuse_mount$handle() {
         return fuse_mount.HANDLE;
     }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * int fuse_mount(struct fuse *f, const char *mountpoint)
+     * }
+     */
+    public static MemorySegment fuse_mount$address() {
+        return fuse_mount.ADDR;
+    }
+
     /**
      * {@snippet lang=c :
      * int fuse_mount(struct fuse *f, const char *mountpoint)
@@ -448,9 +475,9 @@ public class fuse_h {
             fuse_h.C_POINTER
         );
 
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_unmount"),
-                    DESC);
+        public static final MemorySegment ADDR = fuse_h.findOrThrow("fuse_unmount");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
 
     /**
@@ -472,6 +499,17 @@ public class fuse_h {
     public static MethodHandle fuse_unmount$handle() {
         return fuse_unmount.HANDLE;
     }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * void fuse_unmount(struct fuse *f)
+     * }
+     */
+    public static MemorySegment fuse_unmount$address() {
+        return fuse_unmount.ADDR;
+    }
+
     /**
      * {@snippet lang=c :
      * void fuse_unmount(struct fuse *f)
@@ -494,9 +532,9 @@ public class fuse_h {
             fuse_h.C_POINTER
         );
 
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_destroy"),
-                    DESC);
+        public static final MemorySegment ADDR = fuse_h.findOrThrow("fuse_destroy");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
 
     /**
@@ -518,6 +556,17 @@ public class fuse_h {
     public static MethodHandle fuse_destroy$handle() {
         return fuse_destroy.HANDLE;
     }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * void fuse_destroy(struct fuse *f)
+     * }
+     */
+    public static MemorySegment fuse_destroy$address() {
+        return fuse_destroy.ADDR;
+    }
+
     /**
      * {@snippet lang=c :
      * void fuse_destroy(struct fuse *f)
@@ -541,9 +590,9 @@ public class fuse_h {
             fuse_h.C_POINTER
         );
 
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_loop"),
-                    DESC);
+        public static final MemorySegment ADDR = fuse_h.findOrThrow("fuse_loop");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
 
     /**
@@ -565,6 +614,17 @@ public class fuse_h {
     public static MethodHandle fuse_loop$handle() {
         return fuse_loop.HANDLE;
     }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * int fuse_loop(struct fuse *f)
+     * }
+     */
+    public static MemorySegment fuse_loop$address() {
+        return fuse_loop.ADDR;
+    }
+
     /**
      * {@snippet lang=c :
      * int fuse_loop(struct fuse *f)
@@ -587,9 +647,9 @@ public class fuse_h {
             fuse_h.C_POINTER
         );
 
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_exit"),
-                    DESC);
+        public static final MemorySegment ADDR = fuse_h.findOrThrow("fuse_exit");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
 
     /**
@@ -611,6 +671,17 @@ public class fuse_h {
     public static MethodHandle fuse_exit$handle() {
         return fuse_exit.HANDLE;
     }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * void fuse_exit(struct fuse *f)
+     * }
+     */
+    public static MemorySegment fuse_exit$address() {
+        return fuse_exit.ADDR;
+    }
+
     /**
      * {@snippet lang=c :
      * void fuse_exit(struct fuse *f)
@@ -635,9 +706,9 @@ public class fuse_h {
             fuse_h.C_POINTER
         );
 
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_loop_mt"),
-                    DESC);
+        public static final MemorySegment ADDR = fuse_h.findOrThrow("fuse_loop_mt");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
 
     /**
@@ -659,6 +730,17 @@ public class fuse_h {
     public static MethodHandle fuse_loop_mt$handle() {
         return fuse_loop_mt.HANDLE;
     }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * int fuse_loop_mt(struct fuse *f, struct fuse_loop_config *config)
+     * }
+     */
+    public static MemorySegment fuse_loop_mt$address() {
+        return fuse_loop_mt.ADDR;
+    }
+
     /**
      * {@snippet lang=c :
      * int fuse_loop_mt(struct fuse *f, struct fuse_loop_config *config)
@@ -682,9 +764,9 @@ public class fuse_h {
             fuse_h.C_POINTER
         );
 
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
-                    fuse_h.findOrThrow("fuse_get_session"),
-                    DESC);
+        public static final MemorySegment ADDR = fuse_h.findOrThrow("fuse_get_session");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
 
     /**
@@ -706,6 +788,17 @@ public class fuse_h {
     public static MethodHandle fuse_get_session$handle() {
         return fuse_get_session.HANDLE;
     }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * struct fuse_session *fuse_get_session(struct fuse *f)
+     * }
+     */
+    public static MemorySegment fuse_get_session$address() {
+        return fuse_get_session.ADDR;
+    }
+
     /**
      * {@snippet lang=c :
      * struct fuse_session *fuse_get_session(struct fuse *f)

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/fuse3/fuse_loop_config_v1.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/fuse3/fuse_loop_config_v1.java
@@ -155,7 +155,7 @@ public class fuse_loop_config_v1 {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -163,7 +163,7 @@ public class fuse_loop_config_v1 {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/fuse3/fuse_operations.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/fuse3/fuse_operations.java
@@ -4355,7 +4355,7 @@ public class fuse_operations {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -4363,7 +4363,7 @@ public class fuse_operations {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/fuse3/stat.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/fuse3/stat.java
@@ -786,7 +786,7 @@ public class stat {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -794,7 +794,7 @@ public class stat {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/fuse3/statvfs.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/fuse3/statvfs.java
@@ -26,7 +26,8 @@ import static java.lang.foreign.MemoryLayout.PathElement.*;
  *     unsigned long f_fsid;
  *     unsigned long f_flag;
  *     unsigned long f_namemax;
- *     int __f_spare[6];
+ *     unsigned int f_type;
+ *     int __f_spare[5];
  * }
  * }
  */
@@ -48,7 +49,8 @@ public class statvfs {
         fuse_h.C_LONG.withName("f_fsid"),
         fuse_h.C_LONG.withName("f_flag"),
         fuse_h.C_LONG.withName("f_namemax"),
-        MemoryLayout.sequenceLayout(6, fuse_h.C_INT).withName("__f_spare")
+        fuse_h.C_INT.withName("f_type"),
+        MemoryLayout.sequenceLayout(5, fuse_h.C_INT).withName("__f_spare")
     ).withName("statvfs");
 
     /**
@@ -542,24 +544,68 @@ public class statvfs {
         struct.set(f_namemax$LAYOUT, f_namemax$OFFSET, fieldValue);
     }
 
+    private static final OfInt f_type$LAYOUT = (OfInt)$LAYOUT.select(groupElement("f_type"));
+
+    /**
+     * Layout for field:
+     * {@snippet lang=c :
+     * unsigned int f_type
+     * }
+     */
+    public static final OfInt f_type$layout() {
+        return f_type$LAYOUT;
+    }
+
+    private static final long f_type$OFFSET = 88;
+
+    /**
+     * Offset for field:
+     * {@snippet lang=c :
+     * unsigned int f_type
+     * }
+     */
+    public static final long f_type$offset() {
+        return f_type$OFFSET;
+    }
+
+    /**
+     * Getter for field:
+     * {@snippet lang=c :
+     * unsigned int f_type
+     * }
+     */
+    public static int f_type(MemorySegment struct) {
+        return struct.get(f_type$LAYOUT, f_type$OFFSET);
+    }
+
+    /**
+     * Setter for field:
+     * {@snippet lang=c :
+     * unsigned int f_type
+     * }
+     */
+    public static void f_type(MemorySegment struct, int fieldValue) {
+        struct.set(f_type$LAYOUT, f_type$OFFSET, fieldValue);
+    }
+
     private static final SequenceLayout __f_spare$LAYOUT = (SequenceLayout)$LAYOUT.select(groupElement("__f_spare"));
 
     /**
      * Layout for field:
      * {@snippet lang=c :
-     * int __f_spare[6]
+     * int __f_spare[5]
      * }
      */
     public static final SequenceLayout __f_spare$layout() {
         return __f_spare$LAYOUT;
     }
 
-    private static final long __f_spare$OFFSET = 88;
+    private static final long __f_spare$OFFSET = 92;
 
     /**
      * Offset for field:
      * {@snippet lang=c :
-     * int __f_spare[6]
+     * int __f_spare[5]
      * }
      */
     public static final long __f_spare$offset() {
@@ -569,7 +615,7 @@ public class statvfs {
     /**
      * Getter for field:
      * {@snippet lang=c :
-     * int __f_spare[6]
+     * int __f_spare[5]
      * }
      */
     public static MemorySegment __f_spare(MemorySegment struct) {
@@ -579,19 +625,19 @@ public class statvfs {
     /**
      * Setter for field:
      * {@snippet lang=c :
-     * int __f_spare[6]
+     * int __f_spare[5]
      * }
      */
     public static void __f_spare(MemorySegment struct, MemorySegment fieldValue) {
         MemorySegment.copy(fieldValue, 0L, struct, __f_spare$OFFSET, __f_spare$LAYOUT.byteSize());
     }
 
-    private static long[] __f_spare$DIMS = { 6 };
+    private static long[] __f_spare$DIMS = { 5 };
 
     /**
      * Dimensions for array field:
      * {@snippet lang=c :
-     * int __f_spare[6]
+     * int __f_spare[5]
      * }
      */
     public static long[] __f_spare$dimensions() {
@@ -602,7 +648,7 @@ public class statvfs {
     /**
      * Indexed getter for field:
      * {@snippet lang=c :
-     * int __f_spare[6]
+     * int __f_spare[5]
      * }
      */
     public static int __f_spare(MemorySegment struct, long index0) {
@@ -612,7 +658,7 @@ public class statvfs {
     /**
      * Indexed setter for field:
      * {@snippet lang=c :
-     * int __f_spare[6]
+     * int __f_spare[5]
      * }
      */
     public static void __f_spare(MemorySegment struct, long index0, int fieldValue) {
@@ -648,7 +694,7 @@ public class statvfs {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -656,7 +702,7 @@ public class statvfs {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/fuse3/timespec.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/fuse3/timespec.java
@@ -155,7 +155,7 @@ public class timespec {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -163,7 +163,7 @@ public class timespec {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/fuse3_lowlevel/fuse_cmdline_opts.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/extr/fuse3_lowlevel/fuse_cmdline_opts.java
@@ -524,7 +524,7 @@ public class fuse_cmdline_opts {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, Arena arena, Consumer<MemorySegment> cleanup) {
@@ -532,7 +532,7 @@ public class fuse_cmdline_opts {
     }
 
     /**
-     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction) (if any).
+     * Reinterprets {@code addr} using target {@code arena} and {@code cleanupAction} (if any).
      * The returned segment has size {@code elementCount * layout().byteSize()}
      */
     public static MemorySegment reinterpret(MemorySegment addr, long elementCount, Arena arena, Consumer<MemorySegment> cleanup) {

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/fuse_hHelper.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/fuse_hHelper.java
@@ -1,0 +1,76 @@
+package org.cryptomator.jfuse.linux.amd64;
+
+import org.cryptomator.jfuse.linux.amd64.extr.fuse3.fuse_h;
+
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.invoke.MethodHandle;
+
+/**
+ * Class for not jextract'able symbols, e.g. fuse_new
+ * <p>
+ * Structure to access symbols is the same as in the jextract-generated code.
+ */
+public class fuse_hHelper {
+
+	private static final String FUSE_NEW_SYMBOLNAME = "fuse_new_31";
+
+	static final SymbolLookup SYMBOL_LOOKUP = SymbolLookup.loaderLookup()
+			.or(Linker.nativeLinker().defaultLookup());
+
+	static MemorySegment findOrThrow(String symbol) {
+		return SYMBOL_LOOKUP.find(symbol)
+				.orElseThrow(() -> new UnsatisfiedLinkError("unresolved symbol: " + symbol));
+	}
+
+	private static class fuse_new {
+		public static final FunctionDescriptor DESC = FunctionDescriptor.of(
+				fuse_h.C_POINTER,
+				fuse_h.C_POINTER,
+				fuse_h.C_POINTER,
+				fuse_h.C_LONG,
+				fuse_h.C_POINTER
+		);
+
+		public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(
+				findOrThrow(FUSE_NEW_SYMBOLNAME),
+				DESC);
+	}
+
+	/**
+	 * Function descriptor for:
+	 * {@snippet lang = c:
+	 * struct fuse *fuse_new(struct fuse_args *args, const struct fuse_operations *op, size_t op_size, void *private_data)
+	 *}
+	 */
+	public static FunctionDescriptor fuse_new$descriptor() {
+		return fuse_new.DESC;
+	}
+
+
+	/**
+	 * Downcall method handle for:
+	 * {@snippet lang = c:
+	 * struct fuse *fuse_new(struct fuse_args *args, const struct fuse_operations *op, size_t op_size, void *private_data)
+	 *}
+	 */
+	public static MethodHandle fuse_new$handle() {
+		return fuse_new.HANDLE;
+	}
+
+	/**
+	 * {@snippet lang = c:
+	 * struct fuse *fuse_new(struct fuse_args *args, const struct fuse_operations *op, size_t op_size, void *private_data)
+	 *}
+	 */
+	public static MemorySegment fuse_new(MemorySegment args, MemorySegment op, long op_size, MemorySegment private_data) {
+		var mh$ = fuse_new.HANDLE;
+		try {
+			return (MemorySegment) mh$.invokeExact(args, op, op_size, private_data);
+		} catch (Throwable ex$) {
+			throw new AssertionError("should not reach here", ex$);
+		}
+	}
+}

--- a/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/fuse_hHelper.java
+++ b/jfuse-linux-amd64/src/main/java/org/cryptomator/jfuse/linux/amd64/fuse_hHelper.java
@@ -9,9 +9,7 @@ import java.lang.foreign.SymbolLookup;
 import java.lang.invoke.MethodHandle;
 
 /**
- * Class for not jextract'able symbols, e.g. fuse_new
- * <p>
- * Structure to access symbols is the same as in the jextract-generated code.
+ * Class for not jextract'able symbols, e.g. fuse_new_31
  */
 public class fuse_hHelper {
 

--- a/jfuse-linux-amd64/src/test/java/org/cryptomator/jfuse/linux/amd64/FuseImplTest.java
+++ b/jfuse-linux-amd64/src/test/java/org/cryptomator/jfuse/linux/amd64/FuseImplTest.java
@@ -4,13 +4,12 @@ import org.cryptomator.jfuse.api.FuseConnInfo;
 import org.cryptomator.jfuse.api.FuseMountFailedException;
 import org.cryptomator.jfuse.api.FuseOperations;
 import org.cryptomator.jfuse.api.TimeSpec;
-import org.cryptomator.jfuse.linux.amd64.extr.fuse3_lowlevel.fuse_cmdline_opts;
 import org.cryptomator.jfuse.linux.amd64.extr.fuse3.fuse_config;
 import org.cryptomator.jfuse.linux.amd64.extr.fuse3.fuse_conn_info;
 import org.cryptomator.jfuse.linux.amd64.extr.fuse3.fuse_file_info;
 import org.cryptomator.jfuse.linux.amd64.extr.fuse3.fuse_h;
 import org.cryptomator.jfuse.linux.amd64.extr.fuse3.timespec;
-import org.junit.jupiter.api.AfterEach;
+import org.cryptomator.jfuse.linux.amd64.extr.fuse3_lowlevel.fuse_cmdline_opts;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,7 +19,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Answers;
-import org.mockito.MockedStatic;
+import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 import java.lang.foreign.Arena;
@@ -40,39 +39,48 @@ public class FuseImplTest {
 
 		private List<String> args = List.of("foo", "bar");
 		private FuseImpl fuseImplSpy = Mockito.spy(fuseImpl);
-		private MockedStatic<fuse_h> fuseH;
 
 		@BeforeEach
 		public void setup() {
-			Mockito.doReturn(Mockito.mock(FuseArgs.class)).when(fuseImplSpy).parseArgs(args);
-			fuseH = Mockito.mockStatic(fuse_h.class);
 		}
 
-		@AfterEach
-		public void teardown() {
-			fuseH.close();
+		@Test
+		@DisplayName("first parse, then create, then mount")
+		public void testCallOrder() throws FuseMountFailedException {
+			try (var fuseH = Mockito.mockStatic(fuse_h.class)) {
+				var fuseArgs = Mockito.mock(FuseArgs.class);
+				Mockito.doReturn(fuseArgs).when(fuseImplSpy).parseArgs(args);
+				Mockito.when(fuseImplSpy.createFuseFS(fuseArgs)).thenReturn(MemorySegment.NULL);
+				fuseH.when(() -> fuse_h.fuse_mount(Mockito.any(), Mockito.any())).thenReturn(0);
+				fuseImplSpy.mount(args);
+
+				InOrder executionOrder = Mockito.inOrder(fuseImplSpy, fuseH);
+				executionOrder.verify(fuseImplSpy).parseArgs(args);
+				executionOrder.verify(fuseImplSpy).createFuseFS(fuseArgs);
+				executionOrder.verify(fuseH, () -> fuse_h.fuse_mount(Mockito.any(), Mockito.any()));
+			}
+
 		}
 
 		@Test
 		@DisplayName("MountFailedException when fuse_new fails")
 		public void testFuseNewFails() {
-			fuseH.when(() -> fuse_h.fuse_new(Mockito.any(), Mockito.any(), Mockito.anyLong(), Mockito.any())).thenReturn(MemorySegment.NULL);
-
-			var thrown = Assertions.assertThrows(FuseMountFailedException.class, () -> fuseImplSpy.mount(args));
-
-			fuseH.verify(() -> fuse_h.fuse_mount(Mockito.any(), Mockito.any()), Mockito.never());
-			Assertions.assertEquals("fuse_new failed", thrown.getMessage());
+			try (var fuseH = Mockito.mockStatic(fuse_hHelper.class)) {
+				fuseH.when(() -> fuse_hHelper.fuse_new(Mockito.any(), Mockito.any(), Mockito.anyLong(), Mockito.any())).thenReturn(MemorySegment.NULL);
+				var thrown = Assertions.assertThrows(FuseMountFailedException.class, () -> fuseImplSpy.createFuseFS(Mockito.mock(FuseArgs.class)));
+				Assertions.assertEquals("fuse_new failed", thrown.getMessage());
+			}
 		}
 
 		@Test
 		@DisplayName("MountFailedException when fuse_mount fails")
-		public void testFuseMountFails() {
-			fuseH.when(() -> fuse_h.fuse_new(Mockito.any(), Mockito.any(), Mockito.anyLong(), Mockito.any())).thenReturn(MemorySegment.ofAddress(42L));
-			fuseH.when(() -> fuse_h.fuse_mount(Mockito.any(), Mockito.any())).thenReturn(1);
-
-			var thrown = Assertions.assertThrows(FuseMountFailedException.class, () -> fuseImplSpy.mount(args));
-
-			Assertions.assertEquals("fuse_mount failed", thrown.getMessage());
+		public void testFuseMountFails() throws FuseMountFailedException {
+			try (var fuseH = Mockito.mockStatic(fuse_h.class)) {
+				fuseH.when(() -> fuse_h.fuse_mount(Mockito.any(), Mockito.any())).thenReturn(1);
+				Mockito.when(fuseImplSpy.createFuseFS(Mockito.any())).thenReturn(MemorySegment.NULL);
+				var thrown = Assertions.assertThrows(FuseMountFailedException.class, () -> fuseImplSpy.mount(args));
+				Assertions.assertEquals("fuse_mount failed", thrown.getMessage());
+			}
 		}
 
 	}

--- a/jfuse-linux-amd64/src/test/java/org/cryptomator/jfuse/linux/amd64/FuseImplTest.java
+++ b/jfuse-linux-amd64/src/test/java/org/cryptomator/jfuse/linux/amd64/FuseImplTest.java
@@ -76,6 +76,7 @@ public class FuseImplTest {
 		@DisplayName("MountFailedException when fuse_mount fails")
 		public void testFuseMountFails() throws FuseMountFailedException {
 			try (var fuseH = Mockito.mockStatic(fuse_h.class)) {
+				Mockito.doReturn(Mockito.mock(FuseArgs.class)).when(fuseImplSpy).parseArgs(args);
 				fuseH.when(() -> fuse_h.fuse_mount(Mockito.any(), Mockito.any())).thenReturn(1);
 				Mockito.when(fuseImplSpy.createFuseFS(Mockito.any())).thenReturn(MemorySegment.NULL);
 				var thrown = Assertions.assertThrows(FuseMountFailedException.class, () -> fuseImplSpy.mount(args));

--- a/jfuse-linux-amd64/src/test/java/org/cryptomator/jfuse/linux/amd64/FuseImplTest.java
+++ b/jfuse-linux-amd64/src/test/java/org/cryptomator/jfuse/linux/amd64/FuseImplTest.java
@@ -41,8 +41,8 @@ public class FuseImplTest {
 		@Test
 		@DisplayName("MountFailedException when fuse_new fails")
 		public void testFuseNewFails() {
-			try (var fuseH = Mockito.mockStatic(fuse_hHelper.class)) {
-				fuseH.when(() -> fuse_hHelper.fuse_new(Mockito.any(), Mockito.any(), Mockito.anyLong(), Mockito.any())).thenReturn(MemorySegment.NULL);
+			try (var fuseH = Mockito.mockStatic(FuseFFIHelper.class)) {
+				fuseH.when(() -> FuseFFIHelper.fuse_new_31(Mockito.any(), Mockito.any(), Mockito.anyLong(), Mockito.any())).thenReturn(MemorySegment.NULL);
 				var thrown = Assertions.assertThrows(FuseMountFailedException.class, () -> fuseImplSpy.createFuseFS(Mockito.mock(FuseArgs.class)));
 				Assertions.assertEquals("fuse_new failed", thrown.getMessage());
 			}

--- a/jfuse-linux-amd64/src/test/java/org/cryptomator/jfuse/linux/amd64/FuseImplTest.java
+++ b/jfuse-linux-amd64/src/test/java/org/cryptomator/jfuse/linux/amd64/FuseImplTest.java
@@ -11,7 +11,6 @@ import org.cryptomator.jfuse.linux.amd64.extr.fuse3.fuse_h;
 import org.cryptomator.jfuse.linux.amd64.extr.fuse3.timespec;
 import org.cryptomator.jfuse.linux.amd64.extr.fuse3_lowlevel.fuse_cmdline_opts;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -19,7 +18,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Answers;
-import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 import java.lang.foreign.Arena;
@@ -39,28 +37,6 @@ public class FuseImplTest {
 
 		private List<String> args = List.of("foo", "bar");
 		private FuseImpl fuseImplSpy = Mockito.spy(fuseImpl);
-
-		@BeforeEach
-		public void setup() {
-		}
-
-		@Test
-		@DisplayName("first parse, then create, then mount")
-		public void testCallOrder() throws FuseMountFailedException {
-			try (var fuseH = Mockito.mockStatic(fuse_h.class)) {
-				var fuseArgs = Mockito.mock(FuseArgs.class);
-				Mockito.doReturn(fuseArgs).when(fuseImplSpy).parseArgs(args);
-				Mockito.when(fuseImplSpy.createFuseFS(fuseArgs)).thenReturn(MemorySegment.NULL);
-				fuseH.when(() -> fuse_h.fuse_mount(Mockito.any(), Mockito.any())).thenReturn(0);
-				fuseImplSpy.mount(args);
-
-				InOrder executionOrder = Mockito.inOrder(fuseImplSpy, fuseH);
-				executionOrder.verify(fuseImplSpy).parseArgs(args);
-				executionOrder.verify(fuseImplSpy).createFuseFS(fuseArgs);
-				executionOrder.verify(fuseH, () -> fuse_h.fuse_mount(Mockito.any(), Mockito.any()));
-			}
-
-		}
 
 		@Test
 		@DisplayName("MountFailedException when fuse_new fails")

--- a/jfuse-linux-amd64/src/test/java/org/cryptomator/jfuse/linux/amd64/FuseImplTest.java
+++ b/jfuse-linux-amd64/src/test/java/org/cryptomator/jfuse/linux/amd64/FuseImplTest.java
@@ -52,9 +52,12 @@ public class FuseImplTest {
 		@DisplayName("MountFailedException when fuse_mount fails")
 		public void testFuseMountFails() throws FuseMountFailedException {
 			try (var fuseH = Mockito.mockStatic(fuse_h.class)) {
-				Mockito.doReturn(Mockito.mock(FuseArgs.class)).when(fuseImplSpy).parseArgs(args);
+				var fuseArgs = Mockito.mock(FuseArgs.class);
+				Mockito.doReturn(fuseArgs).when(fuseImplSpy).parseArgs(args);
+				Mockito.when(fuseArgs.mountPoint()).thenReturn(MemorySegment.NULL);
+				Mockito.when(fuseArgs.args()).thenReturn(MemorySegment.NULL);
 				fuseH.when(() -> fuse_h.fuse_mount(Mockito.any(), Mockito.any())).thenReturn(1);
-				Mockito.when(fuseImplSpy.createFuseFS(Mockito.any())).thenReturn(MemorySegment.NULL);
+				Mockito.doReturn(MemorySegment.NULL).when(fuseImplSpy).createFuseFS(Mockito.any());
 				var thrown = Assertions.assertThrows(FuseMountFailedException.class, () -> fuseImplSpy.mount(args));
 				Assertions.assertEquals("fuse_mount failed", thrown.getMessage());
 			}


### PR DESCRIPTION
Closes #114.

libfuse3 does not expose `fuse_new` anymore, only a versioned symbold (`fuse_new_31`). Luckily, this symbol is also present in older lib versions, hence this is used instead. Unfortuntely, the symbol cannot be extracted from fuse.h in verison 3.17.1 due to the use of inline functions and preprocessor definitions. Hence a helper class is added.

Additionally, to the build workflow a job with linux-aarch64 is added.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new helper classes for improved native FFI integration with the FUSE library.
- **Refactor**
	- Streamlined the mounting workflow by isolating filesystem creation logic and enhancing error handling.
- **Chores**
	- Upgraded FUSE support from version 312 to 317 and removed outdated functionality.
	- Enhanced CI/CD pipeline to support testing across multiple Linux environments.
- **Tests**
	- Revised test strategies to align with the new integration and mounting workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->